### PR TITLE
Operation Center: Update Windows NXLog config to use TCP

### DIFF
--- a/docs/integrations/windows.md
+++ b/docs/integrations/windows.md
@@ -121,9 +121,10 @@ First of all, download NXLog at the following link : https://nxlog.co/products/a
 </Input>
 
 <Output rsyslog>
-  Module om_udp
+  Module om_tcp
   Host RSYSLOG_HOST
   Port 514
+  OutputType Syslog_TLS
 
   Exec to_syslog_ietf();
 </Output>


### PR DESCRIPTION
Update NXLog documentation to use `om_tcp` and “octet framing” to send events (with the not so well named option `OutputType Syslog_TLS`).