### PR TITLE
Update auditbeat_linux.md

### DIFF
--- a/docs/integrations/auditbeat_linux.md
+++ b/docs/integrations/auditbeat_linux.md
@@ -237,6 +237,8 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 *.*          -/var/log/syslog
 ```
 
+Please ensure, options `$PrivDropToUser syslog` and `$PrivDropToGroup syslog` are removed, otherwise rsyslog process could not read auditbeat output.
+
 And add a dedicated configuration file for the Auditbeat logs in `/etc/rsyslog.d/8-linux_auditbeat.conf` to be sent to a log concentrator.
 
 ```bash
@@ -280,7 +282,7 @@ sudo apt install rsyslog rsyslog-gnutls wget
 Please ensure the UDP incoming events are allows in the /etc/rsyslog.conf
 ```bash
 ....
-# provides UDP syslog reception
+# provides TCP syslog reception
 module(load="imtcp")
 input(type="imtcp" port="514")
 ....


### PR DESCRIPTION
- Correction of a comment in `/etc/rsyslog.conf` file (the configuration indicates a TCP usage and the above comment indicates UDP)
- Add information about `$PrivDropToGroup` and `$PrivDropToUser` that should be removed to allow rsyslog to read auditbeat output.