### PR TITLE
Monitore directories used by cron

### DIFF
--- a/docs/integrations/auditbeat_linux.md
+++ b/docs/integrations/auditbeat_linux.md
@@ -96,6 +96,13 @@ auditbeat.modules:
   - /sbin
   - /usr/sbin
   - /etc
+  - /var/spool/cron/crontabs
+  - /etc/cron.d
+  - /etc/cron.daily
+  - /etc/cron.hourly
+  - /etc/cron.monthly
+  - /etc/cron.weekly
+
 
   scan_at_start: true
   scan_rate_per_sec: 50 MiB


### PR DESCRIPTION
Those extra directories are required due to the default option `recursive: false` which avoid monitoring subdirectory.