### PR TITLE
suggest a new background for code

### DIFF
--- a/src/sekoiaio.scss
+++ b/src/sekoiaio.scss
@@ -117,7 +117,7 @@ a {
 
 
         pre {
-            background: #f5f8fc;
+            background: #2d2e83;
             border-radius: 3px;
         }
 

--- a/src/sekoiaio.scss
+++ b/src/sekoiaio.scss
@@ -118,6 +118,7 @@ a {
 
         pre {
             background: #f5f8fc;
+            border-radius: 3px;
             border: 0;
 
             code {

--- a/src/sekoiaio.scss
+++ b/src/sekoiaio.scss
@@ -117,8 +117,12 @@ a {
 
 
         pre {
-            background: #2d2e83;
+            background: #f5f8fc;
             border-radius: 3px;
+
+            code {
+                color: #000;
+            }
         }
 
         #content_search {

--- a/src/sekoiaio.scss
+++ b/src/sekoiaio.scss
@@ -119,10 +119,14 @@ a {
         pre {
             background: #f5f8fc;
             border-radius: 3px;
-            border: 0;
 
             code {
                 color: #000;
+                border: 0;
+
+                .string {
+                    color: #000;
+                }
             }
         }
 

--- a/src/sekoiaio.scss
+++ b/src/sekoiaio.scss
@@ -118,7 +118,7 @@ a {
 
         pre {
             background: #f5f8fc;
-            border-radius: 3px;
+            border: 0;
 
             code {
                 color: #000;


### PR DESCRIPTION
~~It's an interesting subject, but I don't know which solution to choose:~~

~~1/ initially I thought we could have a black background. 
But I'm afraid that there are black code snippets somewhere else in the documentation which would make the code invisible.~~ 

![Capture d’écran 2022-01-19 à 11 30 21](https://user-images.githubusercontent.com/66947157/150113018-def3f3a2-94b4-44ff-b1f4-c41b96e19fd2.png)


~~2/ So I thought of a grey background, which would work with both types of code colours (and would keep a good contrast).~~ 

![Capture d’écran 2022-01-19 à 11 30 32](https://user-images.githubusercontent.com/66947157/150113129-f10ab8ce-0d4c-47ea-ba4e-4d9ec8dfa05e.png)


~~3/ Alternatively a blue background that reminds the colour of the header navigation.~~

![Capture d’écran 2022-01-19 à 11 24 35](https://user-images.githubusercontent.com/66947157/150113170-b2bf1cfb-9416-4fbb-b128-c04b8dcf08d4.png)


~~4/ But otherwise nothing, to have a pink like the colour of the right section. But I feel like that's what's been tried to be changed. Maybe you want me to remove that pink colour on the right section too?~~

![Capture d’écran 2022-01-19 à 11 30 39](https://user-images.githubusercontent.com/66947157/150113197-1b17f67a-58ea-468b-ba56-6b06a19fc69e.png)

# Proposal 

![Capture d’écran 2022-01-19 à 11 38 50](https://user-images.githubusercontent.com/66947157/150114787-56f2d4c5-4f7e-4acf-97d3-2a93b06a9a6f.png)



~~(my commit implements solution 3)~~

Let me know :)  

Poke @squioc
