### PR TITLE
fix: Add some redirections for API documentations

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -52,7 +52,10 @@ jobs:
         run: |
           echo ${{ github.event.number }} > ./site/.pr_number
 
+      - run: |
+          tar zcvf site.tar.gz -C site .
+
       - uses: actions/upload-artifact@v2
         with:
-          name: site
-          path: site/
+          name: site.tar.gz
+          path: site.tar.gz

--- a/.github/workflows/upload-preview.yaml
+++ b/.github/workflows/upload-preview.yaml
@@ -22,7 +22,7 @@ jobs:
                run_id: ${{github.event.workflow_run.id }},
             });
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "site"
+              return artifact.name == "site.tar.gz"
             })[0];
             var download = await github.actions.downloadArtifact({
                owner: context.repo.owner,
@@ -33,7 +33,9 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/site.zip', Buffer.from(download.data));
 
-      - run: unzip -d site site.zip
+      - run: |
+          unzip -d site site.tar.gz.zip
+          tar zxvf site.tar.gz
 
       - name: Get PR number
         id: pr_number

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,6 +192,21 @@ plugins:
       integrations/pulse-connect-secure.md: integrations/pulse.md
       integrations/sentinelone-deepvisibility.md: integrations/sentinelone_deepvisibility.md
       integrations/umbrella-dns.md: integrations/umbrella_dns.md
+
+      # REST API Documentation
+      apis.md: develop.md
+      "api/operation center: rules, entities, intakes, events.md": develop/rest_api/operation_center/configuration.md
+      "api/operation center: alerts & case management": develop/rest_api/operation_center/alert.md
+      "api/operation center: asset management": develop/rest_api/operation_center/assets.md
+      "api/ingest: manage and test event parsers": develop/rest_api/operation_center/parser.md
+      "api/intelligence center: cyber threat intelligence database": develop/rest_api/intelligence_center/intelligence.md
+      "api/intelligence center: enrichment": develop/rest_api/intelligence_center/enrichments.md
+      "api/profile & permissions": develop/rest_api/community.md
+      "api/dashboards": develop/rest_api/dashboard.md
+      "api/identity & authentication": develop/rest_api/identity_and_authentication.md
+      "api/notifications": develop/rest_api/notification.md
+      "api/automation: symphony orchestrator": develop/rest_api/playbooks.md
+
 - redoc
 repo_url: https://github.com/SEKOIA-IO/documentation
 site_name: SEKOIA.IO Documentation


### PR DESCRIPTION
API documentation URLs were moved from `/apis` and `/api/xxx` to a new set of URLs (more information in #153). This PR only add redirections for the old set of URLs.