### PR TITLE
feat: Only show “public” endpoints in REST API documentations

### DIFF
--- a/docs/develop/rest_api/community.md
+++ b/docs/develop/rest_api/community.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/swagger.json!!
+!!redoc https://api.sekoia.io/v1/swagger.json?context=public!!

--- a/docs/develop/rest_api/dashboard.md
+++ b/docs/develop/rest_api/dashboard.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/dashboard/swagger.json!!
+!!redoc https://api.sekoia.io/v1/dashboard/swagger.json?context=public!!

--- a/docs/develop/rest_api/identity_and_authentication.md
+++ b/docs/develop/rest_api/identity_and_authentication.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/apiauth/swagger.json!!
+!!redoc https://api.test.sekoia.io/v1/apiauth/swagger.json?context=public!!

--- a/docs/develop/rest_api/intelligence_center/enrichments.md
+++ b/docs/develop/rest_api/intelligence_center/enrichments.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/enricher/swagger.json!!
+!!redoc https://api.sekoia.io/v1/enricher/swagger.json?context=public!!

--- a/docs/develop/rest_api/intelligence_center/intelligence.md
+++ b/docs/develop/rest_api/intelligence_center/intelligence.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v2/inthreat/swagger.json!!
+!!redoc https://api.sekoia.io/v2/inthreat/swagger.json?context=public!!

--- a/docs/develop/rest_api/notification.md
+++ b/docs/develop/rest_api/notification.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/notification/swagger.json!!
+!!redoc https://api.sekoia.io/v1/notification/swagger.json?context=public!!

--- a/docs/develop/rest_api/operation_center/alert.md
+++ b/docs/develop/rest_api/operation_center/alert.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/sic/swagger.json!!
+!!redoc https://api.sekoia.io/v1/sic/swagger.json?context=public!!

--- a/docs/develop/rest_api/operation_center/assets.md
+++ b/docs/develop/rest_api/operation_center/assets.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/asset-management/swagger.json!!
+!!redoc https://api.sekoia.io/v1/asset-management/swagger.json?context=public!!

--- a/docs/develop/rest_api/operation_center/configuration.md
+++ b/docs/develop/rest_api/operation_center/configuration.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/sic/conf/swagger.json!!
+!!redoc https://api.sekoia.io/v1/sic/conf/swagger.json?context=public!!

--- a/docs/develop/rest_api/operation_center/parser.md
+++ b/docs/develop/rest_api/operation_center/parser.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/ingest/swagger.json!!
+!!redoc https://api.sekoia.io/v1/ingest/swagger.json?context=public!!

--- a/docs/develop/rest_api/playbooks.md
+++ b/docs/develop/rest_api/playbooks.md
@@ -5,4 +5,4 @@ hide:
   - footer
 ---
 
-!!redoc https://api.sekoia.io/v1/symphony/swagger.json!!
+!!redoc https://api.sekoia.io/v1/symphony/swagger.json?context=public!!


### PR DESCRIPTION
This way, only “public” documentation for our REST APIs will be shown (hide internal endpoints and non-usable endpoints for the general public).