### PR TITLE
feat(ic/api): enhancement to the example script

### DIFF
--- a/docs/intelligence_center/api.md
+++ b/docs/intelligence_center/api.md
@@ -122,11 +122,16 @@ def get_new_objects(feed_id=DEFAULT_FEED, limit=2000):
             if feed_id in cursors:
                 paginated_url = f"{url}&cursor={cursors[feed_id].decode('ascii')}"
 
-            # Request the next batch of objects from the API, authenticate with the APIKEY
-            response = requests.get(
-                paginated_url, headers={"Authorization": f"Bearer {APIKEY}"}
-            )
-            response.raise_for_status()
+            # Retry on error
+            request_successful = False
+            while not request_successful:
+                # Request the next batch of objects from the API, authenticate with the APIKEY
+                response = requests.get(
+                    paginated_url, headers={"Authorization": f"Bearer {APIKEY}"}
+                )
+                print(f"{paginated_url} returned {response.status_code}")
+                request_successful = response.ok
+
             data = response.json()
 
             # Yield individual STIX Objects (SDO & SRO)

--- a/docs/intelligence_center/api.md
+++ b/docs/intelligence_center/api.md
@@ -144,6 +144,10 @@ def get_new_objects(feed_id=DEFAULT_FEED, limit=2000):
             # Stop current iteration if we reached the last updated object
             if not data["items"] or len(data["items"]) < limit:
                 break
+
+# Example usage of the iterator that retrieves new objects from the feed
+for obj in get_new_objects():
+    print(obj)
 ```
 
 ## Getting an indicator's context


### PR DESCRIPTION
The example script to fetch new objects crashes whenever an error happens, which is annoying for a process that runs over a few hours.

This PR makes it indefinitely retry on error and logs HTTP response code to stdout.

It also makes it do something by default, so that copy/pasting the script works instantly (once the APIKEY is replaced)