### PR TITLE
ci: Add a new GitHub Actions script to update intakes documentation

### DIFF
--- a/.github/workflows/update-intakes-documentation.yaml
+++ b/.github/workflows/update-intakes-documentation.yaml
@@ -1,0 +1,51 @@
+name: Update intakes documentation
+on:
+  repository_dispatch:
+    types: [rebuild-intake-documentation]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout `documentation` repository under `main/`
+      uses: actions/checkout@v2
+      with:
+        path: main
+
+    - name: Checkout `intake-formats` repository under `intakes/`
+      uses: actions/checkout@v2
+      with:
+        repository: SEKOIA-IO/intake-formats
+        path: intakes
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      id: setup-python
+      with:
+        python-version: '3.9'
+
+    - name: Install Poetry
+      run: |
+        pip install poetry
+        poetry config virtualenvs.in-project true
+
+    - name: Install dependencies
+      run: |
+        poetry install
+      working-directory: ./main/scripts/update_mkdocs
+
+    - name: Refresh intakes documentation
+      run: |
+        poetry run python update_mkdocs.py $GITHUB_WORKSPACE/intakes $GITHUB_WORKSPACE/main
+      working-directory: ./main/scripts/update_mkdocs
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: Refresh intakes documentation
+        delete-branch: true
+        title: Refresh intakes documentation
+        base: master
+        path: ./main
+        body: |
+          Refresh intakes documentation

--- a/scripts/update_mkdocs/templates/intake.md.jinja
+++ b/scripts/update_mkdocs/templates/intake.md.jinja
@@ -1,8 +1,9 @@
+{#- mode: jinja -#}
 {% if manifest.get('data_sources') or parser['kind'] or parser['category'] or parser['type'] %}
 ## Event Categories
 
 {% if manifest.get('data_sources') %}
-The following Table lists the data source offered by this integration.
+The following table lists the data source offered by this integration.
 
 | Data Source | Description                          |
 | ----------- | ------------------------------------ |
@@ -42,7 +43,7 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
 {% if parser['fields'] %}
 ## Extracted Fields
 
-The following Table lists the fields that are extracted, normalized under the ECS format, analyzed and indexed by the parser. It should be noted that infered fields are not listed.
+The following table lists the fields that are extracted, normalized under the ECS format, analyzed and indexed by the parser. It should be noted that infered fields are not listed.
 
 | Name | Type | Description                |
 | ---- | ---- | ---------------------------|

--- a/scripts/update_mkdocs/update_mkdocs.py
+++ b/scripts/update_mkdocs/update_mkdocs.py
@@ -141,7 +141,7 @@ def generate_intake_doc(intake: Dict) -> str:
     file_loader = FileSystemLoader("templates")
     env = Environment(loader=file_loader)
 
-    template = env.get_template("intake.md")
+    template = env.get_template("intake.md.jinja")
     return template.render(
         manifest=intake["manifest"],
         fields=intake["fields"],


### PR DESCRIPTION
Creates a new GitHub Actions workflow that will be triggered by the `intake-format` repository (via a `repository_dispatch` event). By using a dedicated GitHub App, we are limiting allowed rights to this repository.

When a `repository_dispatch` event is received, this workflow will be executed and will generates intakes documentation and creates a new pull request (in the future, this PR might be auto-merged).

To work as expected, this requires https://github.com/SEKOIA-IO/intake-formats/pull/35 to be merged.
