### PR TITLE
Add box shadow on header to make content more readable

### DIFF
--- a/src/sekoiaio.scss
+++ b/src/sekoiaio.scss
@@ -12,7 +12,6 @@
 
 .md-header {
     background-color: #ffffff;
-    box-shadow: inherit;
     color: #111233;
 
     &[data-md-state='shadow'] {


### PR DESCRIPTION
While reading a doc I noticed that the separation between the header and the content was not very clear, and hindered a bit the reading

# Currently

https://user-images.githubusercontent.com/66947157/177781240-ff1b53be-9a28-4b3c-991a-e0583737b912.mov


# Proposal

https://user-images.githubusercontent.com/66947157/177781349-54251744-e188-44a6-af3d-5f14f59bdaa4.mov


