### PR TITLE
feat: Move SEKOIA.IO Agent documentation to integrations

### DIFF
--- a/docs/xdr/features/collect/integrations/endpoint/sekoiaio.md
+++ b/docs/xdr/features/collect/integrations/endpoint/sekoiaio.md
@@ -9,6 +9,8 @@ SEKOIA.IO provides its own agent allowing to collect interresting events with a 
 !!! note
     The SEKOIA.IO agent is currently in beta and for Windows only.
 
+{!_shared_content/operations_center/integrations/generated/sekoiaio-endpoint_do_not_edit_manually.md!}
+
 ## Installation
 
 ### Intake creation and download of the executable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,6 @@ nav:
     - Collect:
       - Overview: xdr/features/collect/ingestion_methods/index.md
       - Ingestion methods:
-        - SEKOIA.IO Agent: xdr/features/collect/ingestion_methods/sekoiaio.md
         - Rsyslog: xdr/features/collect/ingestion_methods/rsyslog.md
         - Logstash: xdr/features/collect/ingestion_methods/logstash.md
         - syslog-ng: xdr/features/collect/ingestion_methods/syslog-ng.md
@@ -95,6 +94,7 @@ nav:
           - HarfangLab: xdr/features/collect/integrations/endpoint/harfanglab.md
           - Linux: xdr/features/collect/integrations/endpoint/linux.md
           - Panda Security Aether: xdr/features/collect/integrations/endpoint/panda_security_aether.md
+          - SEKOIA.IO Agent: xdr/features/collect/integrations/endpoint/sekoiaio.md
           - SentinelOne: xdr/features/collect/integrations/endpoint/sentinelone.md
           - SentinelOne Deep Visibility: xdr/features/collect/integrations/endpoint/sentinelone_deepvisibility.md
           - Tanium: xdr/features/collect/integrations/endpoint/tanium.md
@@ -590,6 +590,7 @@ plugins:
       user_center/apikeys.md: getting_started/generate_api_keys.md
       user_center/multi_factor_authentication.md: getting_started/account_security.md
       user_center/notifications.md: getting_started/notifications.md
+      xdr/features/collect/ingestion_methods/sekoiaio.md: xdr/features/collect/integrations/endpoint/sekoiaio.md
 - redoc
 - intakes_by_uuid
 repo_url: https://github.com/SEKOIA-IO/documentation


### PR DESCRIPTION
Proposal to move the SEKOIA.IO Agent documentation from the “ingestion methods” category to the “integrations” section.

BTW, we should also find a way to make this new agent more visible in the documentation (via use cases?).