### PR TITLE
Fix(vectra): Page title

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,7 +136,7 @@ nav:
           - Squid: xdr/features/collect/integrations/network/squid.md
           - Stormshield: xdr/features/collect/integrations/network/stormshield_network_security.md
           - Suricata: xdr/features/collect/integrations/network/suricata.md
-          - Vectra: xdr/features/collect/integrations/network/vectra.md
+          - Vectra Cognito Detect: xdr/features/collect/integrations/network/vectra.md
           - Wallix: xdr/features/collect/integrations/network/wallix.md
           - Zeek: xdr/features/collect/integrations/network/zeek.md
         - Generic:


### PR DESCRIPTION
fix for https://chat.sekoia.fr/sekoia/pl/9yzwcdne7ibtmcc6z7jtu3go4c

![Screenshot from 2022-10-11 14-33-29](https://user-images.githubusercontent.com/8960084/195092811-b807ff6b-de76-4a2f-a90e-7995d6783e39.png)

to 
![image](https://user-images.githubusercontent.com/8960084/195092719-fef4c6a5-9b51-4630-91f6-806baa16364c.png)
