### PR TITLE
fix: Fixes preview workflows

### DIFF
--- a/.github/workflows/delete-preview.yaml
+++ b/.github/workflows/delete-preview.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/github-script@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},

--- a/.github/workflows/upload-preview.yaml
+++ b/.github/workflows/upload-preview.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/github-script@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},


### PR DESCRIPTION
See breaking changes: https://github.com/actions/github-script#breaking-changes-in-v5

> As part of this update, the Octokit context available via github no longer has REST methods directly. These methods are available via github.rest.*