### PR TITLE
fix(sekoia-io-activites-logs): fix a typo

### DIFF
--- a/docs/xdr/features/collect/integrations/application/sekoiaio_activity_logs.md
+++ b/docs/xdr/features/collect/integrations/application/sekoiaio_activity_logs.md
@@ -3,7 +3,8 @@ name: SEKOIA.IO activity logs
 type: intake
 
 ## Overview
-SEKOIA.IO activity logs collect operations done, on SEKOIA.IO, by the members of the community. It helps to monitor activities and detect malicious behavior. The activity logs collect various operations such as
+SEKOIA.IO activity logs collect operations done, on SEKOIA.IO, by the members of the community. It helps to monitor activities and detect malicious behavior. The activity logs collect various operations such as:
+
 - listing observables
 - creating a new rule
 - updating the status of an alert


### PR DESCRIPTION
Fix a typo (a list was not correctly displayed)