### PR TITLE
docs(aws-gateway): add endpoint documentation for API

### DIFF
--- a/docs/cti/develop/rest_api/aws-gateway.md
+++ b/docs/cti/develop/rest_api/aws-gateway.md
@@ -1,0 +1,8 @@
+---
+hide:
+  - navigation
+  - toc
+  - footer
+---
+
+!!redoc https://api.sekoia.io/v1/aws-gateway/openapi.json!!

--- a/docs/cti/develop/rest_api/aws-gateway.md
+++ b/docs/cti/develop/rest_api/aws-gateway.md
@@ -1,8 +1,0 @@
----
-hide:
-  - navigation
-  - toc
-  - footer
----
-
-!!redoc https://api.sekoia.io/v1/aws-gateway/openapi.json!!

--- a/docs/cti/develop/rest_api/edl-gateway.md
+++ b/docs/cti/develop/rest_api/edl-gateway.md
@@ -1,0 +1,8 @@
+---
+hide:
+  - navigation
+  - toc
+  - footer
+---
+
+!!redoc https://api.sekoia.io/v1/edl-gateway/openapi.json!!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -271,6 +271,7 @@ nav:
       - Dashboard: cti/develop/rest_api/dashboard.md
       - Notification: cti/develop/rest_api/notification.md
       - Playbooks: cti/develop/rest_api/playbooks.md
+      - AWS Integration: cti/develop/rest_api/aws-gateway.md
 - SEKOIA.IO TIP:
   - Introduction: tip/index.md
   - Features:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -271,7 +271,7 @@ nav:
       - Dashboard: cti/develop/rest_api/dashboard.md
       - Notification: cti/develop/rest_api/notification.md
       - Playbooks: cti/develop/rest_api/playbooks.md
-      - AWS Integration: cti/develop/rest_api/aws-gateway.md
+      - External Dynamic List: cti/develop/rest_api/edl-gateway.md
 - SEKOIA.IO TIP:
   - Introduction: tip/index.md
   - Features:


### PR DESCRIPTION
Even tough the whole AWS integration is not available for customers, I wanted to add the doc for the API endpoint used. Since those endpoints are in production, it could be used internally or if a customer is interested.

Originally, I wanted to add it to this [page](https://docs.sekoia.io/cti/develop/rest_api/intelligence/) but it doesn't seems possible natively.