### PR TITLE
Office365: document Microsoft Defender for 0365

### DIFF
--- a/docs/xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
@@ -18,20 +18,22 @@ SEKOIA.IO can pull four categories of logs from Microsoft Office 365 Management 
 - Microsoft SharePoint audit events (`Audit.SharePoint`)
 - General audit events not included in the other log categories (`Audit.General`)
 
-The [Office 365 Management Activity API Schema](https://docs.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-schema) documents the schema leveraged by SEKOIA.IO to monitor the activities on your Organization. 
+The [Office 365 Management Activity API Schema](https://docs.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-schema) documents the schema leveraged by SEKOIA.IO to monitor activities within your organization. 
 
-Per default, the Audit logging is turned on by default for Microsoft 365 and Office 365 enterprise organizations. However, when setting up an organization, you should verify the auditing status. Microsoft provides instructions to verify and configure the auditing status for your organization in the article [Turn auditing on or off](https://docs.microsoft.com/en-us/microsoft-365/compliance/turn-audit-log-search-on-or-off).
+The Audit logging is turned on by default for Microsoft 365 and Office 365 entreprise organizations. However, when setting up an organization, you should verify the auditing status. 
+
+Microsoft provides instructions to verify and configure the auditing status for your organization in the article [Turn auditing on or off](https://docs.microsoft.com/en-us/microsoft-365/compliance/turn-audit-log-search-on-or-off).
 
 ## Configure
 
 ### Prerequisites
 
-The following are prerequisites to onboard Microsoft 365 logs to SEKOIA.IO:
+To send Microsoft 365 logs to SEKOIA.IO, there are some prerequisites: 
 
-- access to the SEKOIA.IO XDR Operations Center 
-- be a Microsoft Office 365 Administrator to consent to the interconnection
+- Have access to the SEKOIA.IO XDR Operations Center 
+- Be a Microsoft Office 365 Administrator to consent to the interconnection
 
-and to generate logs:
+To generate logs,:
 
 - For some advanced logs, an Azure Premium P1 or Azure Premium P2 license may be required.
 - Configure the Microsoft Office 365 logging in [SEKOIA.IO XDR](https://app.sekoia.io/operations/intakes/new)
@@ -49,21 +51,25 @@ During the setup, SEKOIA.IO requests the following permissions against Microsoft
 
 In order to exploit the automatic interconnection method, please follow these steps:
 
-- Login to the Operations Center
-- Go to Configure > Intakes, and click on `+ INTAKE`
-- Choose Office 365 intake by clicking on `CREATE`
-- Enter the Intake name, select the related Entity and trigger the interconnexion by clicking on `Automatically`
-![SEKOIA.IO Operations Center O365 intake](/assets/operation_center/integration_catalog/cloud_and_saas/o365/intake_creation_o365.png){: style="max-width:60%"}
-- In the displayed modal, click on `LOG IN TO OFFICE 365`, then `ADD PERMISSION INTO OFFICE 365`
-![SEKOIA.IO Operations Center O365 intake](/assets/operation_center/integration_catalog/cloud_and_saas/o365/intake_creation_o365_access.png){: style="max-width:60%"}
-- Choose your Office account, review the permissions and grant them to SEKOIA.IO
+1. Login to the Operations Center
+2. Go to Configure > Intakes, and click on `+ INTAKE`
+3. Choose Office 365 intake by clicking on `CREATE`
+4.Enter the Intake name, select the related Entity and trigger the interconnexion by clicking on `Automatically`
 
-After the integration is created, it may take up to 12 hours for the Microsoft API to make data available for the first time.
+![SEKOIA.IO Operations Center O365 intake](/assets/operation_center/integration_catalog/cloud_and_saas/o365/intake_creation_o365.png){: style="max-width:60%"}
+
+5. In the displayed modal, click on `LOG IN TO OFFICE 365`, then `ADD PERMISSION INTO OFFICE 365`
+
+![SEKOIA.IO Operations Center O365 intake](/assets/operation_center/integration_catalog/cloud_and_saas/o365/intake_creation_o365_access.png){: style="max-width:60%"}
+
+6. Choose your Office account, review the permissions and grant them to SEKOIA.IO
+
+Once the integration created, it may take up to 12 hours for the Microsoft API to make data available for the first time.
 
 
 #### Alternative mode
 
-For any reason, you are unable or you don't want to collect Office 365 logs through the management API,
+If you are unable or you don't want to collect Office 365 logs through the management API,
 SEKOIA.IO also supports Office 365 log collection through Azure EventHub. Follow [this guide](o365_appendix.md) for more details on this solution.
 
 
@@ -75,7 +81,7 @@ Refer to [this guide](https://learn.microsoft.com/en-us/microsoft-365/security/o
 
 ### Enjoy your events
 
-You can go to the [events page](https://app.sekoia.io/operations/events) to watch your incoming events.
+You can go to the [events page](https://app.sekoia.io/operations/events) to access your incoming events.
 
 {!_shared_content/operations_center/integrations/generated/o365_do_not_edit_manually.md!}
 

--- a/docs/xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
@@ -54,7 +54,7 @@ In order to exploit the automatic interconnection method, please follow these st
 1. Login to the Operations Center
 2. Go to Configure > Intakes, and click on `+ INTAKE`
 3. Choose Office 365 intake by clicking on `CREATE`
-4.Enter the Intake name, select the related Entity and trigger the interconnexion by clicking on `Automatically`
+4. Enter the Intake name, select the related Entity and trigger the interconnection by clicking on `Automatically`
 
 ![SEKOIA.IO Operations Center O365 intake](/assets/operation_center/integration_catalog/cloud_and_saas/o365/intake_creation_o365.png){: style="max-width:60%"}
 
@@ -64,7 +64,7 @@ In order to exploit the automatic interconnection method, please follow these st
 
 6. Choose your Office account, review the permissions and grant them to SEKOIA.IO
 
-Once the integration created, it may take up to 12 hours for the Microsoft API to make data available for the first time.
+Once the integration is created, it may take up to 12 hours for the Microsoft API to make data available for the first time.
 
 
 #### Alternative mode
@@ -75,7 +75,7 @@ SEKOIA.IO also supports Office 365 log collection through Azure EventHub. Follow
 
 ### Collect Microsoft Defender for Office365 events
 
-If your organization use Microsoft Defender for Office365, you can forward malware and threat intelligence events to SEKOIA.IO.
+If your organization use Microsoft Defender for Office 365, you can forward malware and threat intelligence events to SEKOIA.IO.
 Refer to [this guide](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/siem-integration-with-office-365-ti) to turn on Defender events in the audit logs. These events will be automatically forward with the Office365 integration.
 
 

--- a/docs/xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
@@ -67,6 +67,12 @@ For any reason, you are unable or you don't want to collect Office 365 logs thro
 SEKOIA.IO also supports Office 365 log collection through Azure EventHub. Follow [this guide](o365_appendix.md) for more details on this solution.
 
 
+### Collect Microsoft Defender for Office365 events
+
+If your organization use Microsoft Defender for Office365, you can forward malware and threat intelligence events to SEKOIA.IO.
+Refer to [this guide](https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/siem-integration-with-office-365-ti) to turn on Defender events in the audit logs. These events will be automatically forward with the Office365 integration.
+
+
 ### Enjoy your events
 
 You can go to the [events page](https://app.sekoia.io/operations/events) to watch your incoming events.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
             - Azure Windows: xdr/features/collect/integrations/cloud_and_saas/azure/azure_windows.md
           - Microsoft Office 365:
             - Office365: xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
+            - Microsoft Defender for Office365: xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
             - Message trace: xdr/features/collect/integrations/cloud_and_saas/office365/message_trace.md
           - Okta system log: xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
         - Email:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,7 @@ nav:
             - Azure Windows: xdr/features/collect/integrations/cloud_and_saas/azure/azure_windows.md
           - Microsoft Office 365:
             - Office365: xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
-            - Microsoft Defender for Office365: xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
+            - Microsoft Defender for Office 365: xdr/features/collect/integrations/cloud_and_saas/office365/o365.md
             - Message trace: xdr/features/collect/integrations/cloud_and_saas/office365/message_trace.md
           - Okta system log: xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
         - Email:


### PR DESCRIPTION
add section to describe how to turn on Defender events in Office365 audit logs.
add entry in the menu to point Microsoft Defender for 0365.