### PR TITLE
OKTA: update the documentation

### DIFF
--- a/docs/xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
@@ -32,7 +32,7 @@ To start to pull events, you have to:
 
     !!! note
 
-        According your Okta subscription, you may need to decrease the ratelimit_per_minute in the trigger configuration. Please see the [OKTA documentation](https://help.okta.com/en-us/Content/Topics/Security/API.htm) for more information
+        According to your Okta subscription, you may need to decrease the ratelimit_per_minute in the trigger configuration. Please see the [OKTA documentation](https://help.okta.com/en-us/Content/Topics/Security/API.htm) for more information
 
 ## Further Readings
 

--- a/docs/xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
@@ -26,7 +26,7 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 To start to pull events, you have to: 
 
-1. Go to the [playbook page](https://app.sekoia.io/operations/playbooks) and create a new playbook with the [Fetch new system logs from OKTA](../../../automate/library/okta.md)
+1. Go to the [playbooks page](https://app.sekoia.io/operations/playbooks) and create a new playbook with the [Fetch new system logs from OKTA](../../../automate/library/okta.md) trigger
 2. Set up the module configuration with your API Key and the base url of your Okta instance. Set up the trigger configuration with the intake key
 3. Start the playbook and enjoy your events
 

--- a/docs/xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
@@ -24,13 +24,14 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ### Pull events
 
-Go to the [playbook page](https://app.sekoia.io/operations/playbooks) and create a new playbook with the template `Forward Okta system logs with SEKOIA.IO`.
+To start to pull events, you have to: 
 
-Set up the frequency of the `Cron` trigger, copy the API token in the configuration of the `Request URL` action and paste the intake key in the `Push Events to Intake` action.
+1. Go to the [playbook page](https://app.sekoia.io/operations/playbooks) and create a new playbook with the [Fetch new system logs from OKTA](../../../automate/library/okta.md)
+2. Set up the module configuration with your API Key and the base url of your Okta instance. Set up the trigger configuration with the intake key
+    !!! note
 
-Set up the trigger and the action with their module configurations.
-
-Start the playbook and enjoy your events.
+        According your Okta subscription, you may need to decrease the ratelimit_per_minute. See [OKTA documentation](https://help.okta.com/en-us/Content/Topics/Security/API.htm).
+4. Start the playbook and enjoy your events
 
 ## Further Readings
 

--- a/docs/xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/okta_system_log.md
@@ -28,10 +28,11 @@ To start to pull events, you have to:
 
 1. Go to the [playbook page](https://app.sekoia.io/operations/playbooks) and create a new playbook with the [Fetch new system logs from OKTA](../../../automate/library/okta.md)
 2. Set up the module configuration with your API Key and the base url of your Okta instance. Set up the trigger configuration with the intake key
+3. Start the playbook and enjoy your events
+
     !!! note
 
-        According your Okta subscription, you may need to decrease the ratelimit_per_minute. See [OKTA documentation](https://help.okta.com/en-us/Content/Topics/Security/API.htm).
-4. Start the playbook and enjoy your events
+        According your Okta subscription, you may need to decrease the ratelimit_per_minute in the trigger configuration. Please see the [OKTA documentation](https://help.okta.com/en-us/Content/Topics/Security/API.htm) for more information
 
 ## Further Readings
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -202,6 +202,7 @@ nav:
         - MWDB: xdr/features/automate/library/mwdb.md
         - Mandrill: xdr/features/automate/library/mandrill.md
         - Mattermost: xdr/features/automate/library/mattermost.md
+        - OKTA: xdr/features/automate/library/okta.md
         - OSINT: xdr/features/automate/library/osint.md
         - Microsoft Office365: xdr/features/automate/library/microsoft-office365.md
         - Onyphe: xdr/features/automate/library/onyphe.md


### PR DESCRIPTION
update the 'Pull events' section to use the OKTA connector instead of the playbook template