### PR TITLE
Microsoft: fix the documentation after the  renaming of the format MD for Endpoint

### DIFF
--- a/docs/xdr/features/collect/integrations/endpoint/microsoft_defender_for_endpoints.md
+++ b/docs/xdr/features/collect/integrations/endpoint/microsoft_defender_for_endpoints.md
@@ -11,7 +11,7 @@ This setup guide describes how to forward events produced by `Microsoft Defender
 
 {!_shared_content/operations_center/detection/generated/suggested_rules_05e6f36d-cee0-4f06-b575-9e43af779f9f_do_not_edit_manually.md!}
 
-{!_shared_content/operations_center/integrations/generated/microsoft-defender-for-endpoints_do_not_edit_manually.md!}
+{!_shared_content/operations_center/integrations/generated/microsoft-365-defender_do_not_edit_manually.md!}
 
 ## Configure
 
@@ -27,7 +27,7 @@ Then go to `Security + networking > Access keys` and copy the key1 `Connection s
 
 ### Create the intake
 
-Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a new intake from the format `Microsoft Defender for Endpoints`.
+Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a new intake from the format `Microsoft 365 Defender`.
 
 ### Pull events
 


### PR DESCRIPTION
fix the documentation after the renaming of the format