### PR TITLE
Cisco: fix suggested rules

### DIFF
--- a/docs/xdr/features/collect/integrations/network/cisco/cisco_nx_os.md
+++ b/docs/xdr/features/collect/integrations/network/cisco/cisco_nx_os.md
@@ -9,7 +9,7 @@ Cisco NX-OS is a network operating system for Cisco Nexus-series switches.
 !!! warning
     This format is still in beta, please use it wisely.
 
-{!_shared_content/operations_center/detection/generated/suggested_rules_466aeca2-e112-4ccc-a109-c6d85b91bbcf_do_not_edit_manually.md!}
+{!_shared_content/operations_center/detection/generated/suggested_rules_591feb54-1d1f-4453-b780-b225c59e9f99_do_not_edit_manually.md!}
 
 {!_shared_content/operations_center/integrations/generated/591feb54-1d1f-4453-b780-b225c59e9f99.md!}
 


### PR DESCRIPTION
Fix the included suggestion of rules in the documentation of Cisco NX OS (Currently, it's the suggestion of rules for Cisco Secure Firewall).