### PR TITLE
Doc: redirect the user to SEKOIA.IO docker concentrator doc

### DIFF
--- a/docs/xdr/features/collect/integrations/application/apache.md
+++ b/docs/xdr/features/collect/integrations/application/apache.md
@@ -14,7 +14,7 @@ The Apache HTTP Server, colloquially called Apache, is free and open-source cros
 
 As of now, the main solution to collect Apache logs leverages the Rsyslog recipe. Please share your experiences with other recipes by editing this documentation.
 
-### Rsyslog
+### Transport to SEKOIA.IO
 
 This setup guide will show you how to forward both your access and error logs to SEKOIA.IO by means of an rsyslog transport channel. The reader is also invited to consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
 

--- a/docs/xdr/features/collect/integrations/application/freeradius.md
+++ b/docs/xdr/features/collect/integrations/application/freeradius.md
@@ -18,7 +18,7 @@ This setup guide will lead you into forwarding FreeRADIUS's logs to SEKOIA.IO
 
 ### Prerequisites
 
-An internal log concentrator (Rsyslog) is required to collect and forward events to SEKOIA.IO.
+An internal syslog concentrator is required to collect and forward events to SEKOIA.IO.
 
 ### Create the intake in SEKOIA.IO
 
@@ -26,7 +26,7 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ### Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO
 
 ### Enable Syslog forwarding for FreeRADIUS
 

--- a/docs/xdr/features/collect/integrations/email/fortimail.md
+++ b/docs/xdr/features/collect/integrations/email/fortimail.md
@@ -30,11 +30,11 @@ On FortiMail appliances, most of the important hardware and software activities 
 The following prerequisites are needed in order to setup efficient log concentration:
 
 - Have administrator privileges on the FortiMail appliance
-- Traffic towards the Rsyslog must be open on `UDP 514`
+- Traffic towards the syslog must be open on `UDP 514`
 
 ### Configure FortiMail
 
-#### Configure logging to a RSYSLOG server
+#### Configure logging to a syslog server
 
 1. Go to `Log and Report > Log Settings > Remote`.
 2. Click `New` to create a new entry OR double-click an existing entry to modify it. *A dialog appears*.
@@ -55,4 +55,4 @@ For detailed information about configuring a log forwarding, see [Configure Fort
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/endpoint/auditbeat_linux.md
+++ b/docs/xdr/features/collect/integrations/endpoint/auditbeat_linux.md
@@ -18,7 +18,7 @@ Auditbeat communicates directly with the Linux audit framework, collects the sam
 The following prerequisites are needed in order to setup efficient log concentration:
 
 - Have administrator privileges on the server
-- Traffic towards the log collector sever which is using Rsyslog must be open on port `TCP/514`
+- Traffic towards the log collector sever which is using syslog must be open on port `TCP/514`
 
 #### Configure the client
 
@@ -266,7 +266,7 @@ sudo systemctl restart rsyslog.service
 
 ### Transport to SEKOIA.IO
 
-The reader is invited to consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to transport logs to SEKOIA.IO.
+The reader is invited to consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation or [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to transport logs to SEKOIA.IO.
 
 ### Enjoy your events
 Go to the [events page](https://app.sekoia.io/operations/events) to watch your incoming events.

--- a/docs/xdr/features/collect/integrations/endpoint/cybereason_malop_activity.md
+++ b/docs/xdr/features/collect/integrations/endpoint/cybereason_malop_activity.md
@@ -28,7 +28,7 @@ Keep aside the intake key.
 
 ### Setup the Syslog collector
 
-Check the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to install and set up the syslog collector.
+Check the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to install and set up the syslog collector.
 
 Once the setup has completed, write down the IP address and port. This information will be used in the next step.
 

--- a/docs/xdr/features/collect/integrations/endpoint/ibm_aix.md
+++ b/docs/xdr/features/collect/integrations/endpoint/ibm_aix.md
@@ -15,7 +15,7 @@ In this guide, you will configure the gateway to forward events to syslog.
 
 ### Prerequisites
 
-An internal log concentrator (Rsyslog) is required to collect and forward events to SEKOIA.IO.
+An internal syslog concentrator is required to collect and forward events to SEKOIA.IO.
 
 ### Enable Syslog forwarding
 
@@ -28,4 +28,4 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ## Send logs to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/endpoint/symantec_epp.md
+++ b/docs/xdr/features/collect/integrations/endpoint/symantec_epp.md
@@ -16,7 +16,7 @@ In this guide, you will configure your Symantec Endpoint Protection Manager or y
 
 ### Prerequisites
 
-An internal log concentrator (Rsyslog) is required to collect and forward events to SEKOIA.IO.
+An internal syslog concentrator is required to collect and forward events to SEKOIA.IO.
 
 ### Enable Syslog forwarding
 
@@ -29,4 +29,4 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/endpoint/trend_micro_deep_security.md
+++ b/docs/xdr/features/collect/integrations/endpoint/trend_micro_deep_security.md
@@ -17,7 +17,7 @@ In this guide, you will configure your Security Manager to forward events throug
 
 ### Prerequisites
 
-An internal log concentrator (Rsyslog) is required to collect and forward events to SEKOIA.IO.
+An internal syslog concentrator is required to collect and forward events to SEKOIA.IO.
 
 ### Enable Syslog forwarding
 
@@ -51,4 +51,4 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/endpoint/windows.md
+++ b/docs/xdr/features/collect/integrations/endpoint/windows.md
@@ -182,10 +182,10 @@ Please consult the dedicated documentation for each concentrator :
 * [Logstash](../../../ingestion_methods/logstash/)
 * [Syslog-ng](../../../ingestion_methods/syslog-ng/)
 * [Graylog](../../../ingestion_methods/graylog/)
+* [SEKOIA.IO docker concentrator](../../../ingestion_methods/sekoiaio_docker_concentrator/)
 
 !!!Note
-    Rsyslog is now recommanded because it is on this concentrator that SEKOIA has the best expertise.
-    However, feel free to use the one you are the most confortable with.
+    Although SEKOIA.IO docker concentrator is highly recommended, feel free to use the one you are the most confortable with.
 
 ## Windows Event Forwarder to Windows Event Collector to a concentrator
 Most of the following commands are to be run as Administrator in a Powershell interpretor.

--- a/docs/xdr/features/collect/integrations/network/cisco/cisco_asa.md
+++ b/docs/xdr/features/collect/integrations/network/cisco/cisco_asa.md
@@ -38,10 +38,10 @@ hostname(config)# logging trap informational
 The following prerequisites are needed in order to setup efficient log concentration:
 
 - Have administrator privileges on the CISCO appliance
-- Traffic towards the Rsyslog must be open on `UDP 514`
+- Traffic towards the concentrator must be open on `UDP 514`
 
 #### Configure the CISCO Appliance
-In ordre to forward the logs to a Rsyslog, please follow those commands:
+In order to forward the logs to the concentrator, please follow those commands:
 
 > Note the interface name
 ```bash
@@ -76,6 +76,4 @@ Explanations:
 
 ## Transport to SEKOIA.IO
 
-### Rsyslog
-
-The reader is invited to consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+The reader is invited to consult the [Syslog Forwarding](../../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/network/cisco/cisco_meraki_mx.md
+++ b/docs/xdr/features/collect/integrations/network/cisco/cisco_meraki_mx.md
@@ -17,7 +17,7 @@ Cisco Meraki MX is a multifunctional security and SD-WAN enterprise appliance wi
 
 ### Prerequisites
 
-An internal log concentrator (Rsyslog) is required to collect and forward events to SEKOIA.IO.
+An internal log concentrator is required to collect and forward events to SEKOIA.IO.
 
 ### Enable Syslog forwarding
 
@@ -30,7 +30,7 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.
 
 ## Further Readings
 - [Cisco Meraki MX documentation](https://documentation.meraki.com/MX)

--- a/docs/xdr/features/collect/integrations/network/cisco/cisco_nx_os.md
+++ b/docs/xdr/features/collect/integrations/network/cisco/cisco_nx_os.md
@@ -17,7 +17,7 @@ Cisco NX-OS is a network operating system for Cisco Nexus-series switches.
 
 ### Prerequisites
 
-An internal log concentrator (Rsyslog) is required to collect and forward events to SEKOIA.IO.
+An internal log concentrator is required to collect and forward events to SEKOIA.IO.
 
 ### Enable Syslog forwarding
 
@@ -30,7 +30,7 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.
 
 ## Further Readings
 - [Cisco Nexus 9000 Series Documentation](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/6-x/system_management/configuration/guide/b_Cisco_Nexus_9000_Series_NX-OS_System_Management_Configuration_Guide.html)

--- a/docs/xdr/features/collect/integrations/network/f5-big-ip.md
+++ b/docs/xdr/features/collect/integrations/network/f5-big-ip.md
@@ -15,9 +15,13 @@ F5's BIG-IP is a family of products covering software and hardware designed arou
 
 We expect logs formated in priority as CEF or under the reporting format (key/value pairs).
 
-In this setup guide you will set up an rsyslog server to add your intake key and forward securely your BIG-IP logs to our servers. We first explain how to configure your rsyslog server, then we show how to configure a *Log Publisher* to format your logs as CEF and send them to your rsyslog server.
+In this setup guide you will forward securely your BIG-IP logs to our servers. We first explain how to configure your syslog concentrator, then we show how to configure a *Log Publisher* to format your logs as CEF and send them to your syslog concentrator.
 
-Most BIG-IP modules can use Log Publishers, some can directly log messages as CEF to an rsyslog server.
+Most BIG-IP modules can use Log Publishers, some can directly log messages as CEF to a syslog server.
+
+### Set up the concentrator
+
+Please consult the [Syslog Forwarding](../../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to set up the concentrator that will forward your logs to SEKOIA.IO.
 
 ### Configure a Log Publisher
 
@@ -25,8 +29,8 @@ Before creating a log publisher, you first need a *management port* log destinat
 ```
 System -> Logs -> Configuration -> Log Destinations -> Create...
 ```
-Give it a name, choose type `Management Port`, fill the address and port of your rsyslog server and select protocol UDP
-(alternatively you can define a pool of rsyslog servers and use it as a remote high speed log destination).
+Give it a name, choose type `Management Port`, fill the address and port of your syslog concentrator and select protocol UDP
+(alternatively you can define a pool of syslog servers and use it as a remote high speed log destination).
 
 Then you need another log destination to format your logs in CEF:
 ```
@@ -52,18 +56,14 @@ Security -> Event Logs -> Logging Profiles -> Create... -> Publisher
 
 ### Direct Configuration
 
-Some modules allow direct configuration to the rsyslog server. As an example:
+Some modules allow direct configuration to the syslog concentrator. As an example:
 ```
 Security -> Event Logs -> Logging Profiles -> Create...
 ```
-Then choose `Application Security`, select `Remote Storage` as a storage destination, `Common Event Format (ArcSight)` as a logging format, and fill in your rsyslog server info.
+Then choose `Application Security`, select `Remote Storage` as a storage destination, `Common Event Format (ArcSight)` as a logging format, and fill in your syslog concentrator info.
 
 The resulting logging profile can be applied to a given virtual server in:
 ```
 Local Traffic -> Virtual Servers -> Virtual Server List
 ```
 Then choose a virtual server, go to the `Security -> Policies` tab and apply the log profile.
-
-### Rsyslog
-
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/network/forcepoint_web_gateway.md
+++ b/docs/xdr/features/collect/integrations/network/forcepoint_web_gateway.md
@@ -19,7 +19,7 @@ This procedure should be repeated for each Forcepoint Policy Server.
 
 ### Prerequisites
 
-An internal log concentrator (Rsyslog) is required to collect and forward events to SEKOIA.IO.
+An internal syslog concentrator is required to collect and forward events to SEKOIA.IO.
 
 ### Enable SIEM Integration
 
@@ -36,4 +36,4 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/network/fortigate.md
+++ b/docs/xdr/features/collect/integrations/network/fortigate.md
@@ -16,7 +16,7 @@ The range of Fortigate firewalls is a complete appliance solution whose security
 
 In this documentation we explain one way to collect and send Fortigate logs to SEKOIA.IO.
 
-- From the Fortigate machine to an internal log concentrator (Rsyslog), then forwarded to SEKOIA.IO
+- From the Fortigate machine to an internal syslog concentrator, then forwarded to SEKOIA.IO
 
 ## Fortigate logs
 
@@ -34,7 +34,7 @@ On Fortigate appliances, most of the important hardward and software activities 
 The following prerequisites are needed in order to setup efficient log concentration:
 
 - Have administrator writes on the Fortigate
-- Traffic towards the Rsyslog must be open on `TCP/514`
+- Traffic towards the syslog concentrator must be open on `TCP/514`
 
 ### Configure Fortigate
 
@@ -85,4 +85,4 @@ end
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/network/fortiproxy.md
+++ b/docs/xdr/features/collect/integrations/network/fortiproxy.md
@@ -6,7 +6,7 @@ type: intake
 
 FortiProxy is a web proxy that protects clients against internet threats.
 In this documentation we will explain one way to collect and send FortiProxy logs to SEKOIA.IO.
-- From the FortiProxy server to an internal log concentrator (Rsyslog), then forwarded to SEKOIA.IO
+- From the FortiProxy server to an internal syslog concentrator, then forwarded to SEKOIA.IO
 
 
 {!_shared_content/operations_center/detection/generated/suggested_rules_270777d7-0c5a-42fb-b901-b7fadfb0ba48_do_not_edit_manually.md!}
@@ -26,7 +26,7 @@ On FortiProxy appliances, differents type of logs are available. This intake cur
 
 The following prerequisites are needed in order to setup efficient log concentration:
 - Have administrator rights on FortiProxy
-- Traffic towards the Rsyslog must be open on `UDP 514`
+- Traffic towards the syslog concentrator must be open on `UDP 514`
 
 #### Configure logging to a RSYSLOG server
 
@@ -43,4 +43,4 @@ For more information please refer to the official documentation of [FortiProxy](
 
 ### Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/network/fortiweb.md
+++ b/docs/xdr/features/collect/integrations/network/fortiweb.md
@@ -4,7 +4,7 @@ type: intake
 
 ## Overview
 
-This documentation details one way to collect and send FortiWeb logs to SEKOIA.IO: from the FortiWeb machine to an internal log concentrator (Rsyslog), then forwarded to SEKOIA.IO
+This documentation details one way to collect and send FortiWeb logs to SEKOIA.IO: from the FortiWeb machine to an internal syslog concentrator, then forwarded to SEKOIA.IO
 
 
 {!_shared_content/operations_center/detection/generated/suggested_rules_2259adc3-9d93-4150-9c1c-46804e636084_do_not_edit_manually.md!}
@@ -23,7 +23,7 @@ On FortiWeb appliances, most of the important hardware and software activities t
 
 The following prerequisites are needed in order to setup efficient log concentration:
 - Have administrator writes on the FortiWeb (read & write permission)
-- Traffic towards the Rsyslog must be open on `UDP 514`
+- Traffic towards the syslog concentrator must be open on `UDP 514`
 
 #### Configure FortiWeb
 
@@ -58,6 +58,4 @@ For more information please refer to the official documentation of [FortiWeb](ht
 
 ### Transport to SEKOIA.IO
 
-#### Rsyslog
-
-The reader is invited to consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+The reader is invited to consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/network/gatewatcher_aioniq.md
+++ b/docs/xdr/features/collect/integrations/network/gatewatcher_aioniq.md
@@ -13,7 +13,7 @@ Gatewatcher AionIQ is a detection and response platform for your network that id
 
 ### Prerequisites
 
-An internal log concentrator (Rsyslog) is required to collect and forward events to SEKOIA.IO.
+An internal syslog concentrator is required to collect and forward events to SEKOIA.IO.
 
 ### Enable Syslog forwarding
 
@@ -27,7 +27,7 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.
 
 ## Further Readings
 - [GCenter Syslog configuration overview](https://docs.gatewatcher.com/en/gcenter/2.5.3/101/itg-ext/syslog.html)

--- a/docs/xdr/features/collect/integrations/network/infoblox_ddi.md
+++ b/docs/xdr/features/collect/integrations/network/infoblox_ddi.md
@@ -17,7 +17,7 @@ In this guide, you will configure the gateway to forward events to syslog.
 
 ### Prerequisites
 
-An internal log concentrator (Rsyslog) is required to collect and forward events to SEKOIA.IO.
+An internal syslog concentrator is required to collect and forward events to SEKOIA.IO.
 
 ### Enable Syslog forwarding
 
@@ -30,4 +30,4 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/network/microsoft_always_on_vpn.md
+++ b/docs/xdr/features/collect/integrations/network/microsoft_always_on_vpn.md
@@ -13,7 +13,7 @@ This guide will explain how to forward Network Policy Server (NPS) logs to SEKOI
 
 ## Configure
 
-### NXLog agent to the Rsyslog
+### NXLog agent to a syslog concentrator
 
 #### Configuring NPS logging
 
@@ -51,26 +51,26 @@ First of all, download NXLog at the following link : https://nxlog.co/products/a
     File      '%SYSTEMROOT%\System32\LogFile\*.log'
 </Input>
 
-<Output rsyslog>
+<Output concentrator>
   Module om_tcp
-  Host RSYSLOG_HOST
+  Host CONCENTRATOR_HOST
   Port 514
   OutputType Syslog_TLS
 
   Exec to_syslog_ietf();
 </Output>
-<Route eventlog_to_rsyslog>
-  Path eventlog => rsyslog
+<Route eventlog_to_concentrator>
+  Path eventlog => concentrator
 </Route>
 ```
 
-> In the above configuration make sure to replace `RSYSLOG_HOST` variable by your Rsyslog server IP.
+> In the above configuration make sure to replace `CONCENTRATOR_HOST` variable by your syslog concentrator IP.
 
 Restart the NXLog service through the Services tool as Administrator or use Powershell command line: `Restart-Service nxlog`
 
-### Configure the Rsyslog to forward to SEKOIA.IO
+### Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.
 
 ### Enjoy your events
 Go to the [events page](https://app.sekoia.io/operations/events) to watch your incoming events.

--- a/docs/xdr/features/collect/integrations/network/paloalto.md
+++ b/docs/xdr/features/collect/integrations/network/paloalto.md
@@ -70,7 +70,7 @@ For detailed information about configuring a log forwarding profile and assignin
 
 #### Transport to SEKOIA.IO
 
-Please refer to the documentation of the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please refer to the documentation of the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.
 
 ### Forward events through Palo Alto Cortex Data Lake
 

--- a/docs/xdr/features/collect/integrations/network/pulse.md
+++ b/docs/xdr/features/collect/integrations/network/pulse.md
@@ -17,4 +17,4 @@ As of now, the main solution to collect Pulse Secure Connect logs leverages the 
 
 ### Rsyslog
 
-Please refer to the documentation of Pulse Secure Connect to forward events to your rsyslog server. The reader can consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please refer to the documentation of Pulse Secure Connect to forward events to your syslog concentrator. The reader can consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/network/sonicwall_fw.md
+++ b/docs/xdr/features/collect/integrations/network/sonicwall_fw.md
@@ -16,7 +16,7 @@ SonicWall firewalls enable you to identify and control all applications that are
 ## Configure
 
 This setup guide will show you how to forward your SonicWall logs
-to SEKOIA.IO by means of an Rsyslog transport channel.
+to SEKOIA.IO by means of a syslog transport channel.
 
 ### Prerequisites
 
@@ -34,4 +34,4 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ### Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Syslog Forwarding](../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.

--- a/docs/xdr/features/collect/integrations/network/sophos_fw.md
+++ b/docs/xdr/features/collect/integrations/network/sophos_fw.md
@@ -13,7 +13,7 @@ Sophos firewalls offer an integrated software solution that provides superior pe
 ## Configure
 
 This setup guide will show you how to forward your Sophos logs
-to SEKOIA.IO by means of an Rsyslog transport channel.
+to SEKOIA.IO by means of a syslog transport channel.
 
 ### Configure Sophos Firewall
 You can configure a syslog server in Sophos Firewall by following the instructions below (Which is appropriate for an XG Firewall, please refer to your documentation in other cases).
@@ -26,5 +26,7 @@ You can configure a syslog server in Sophos Firewall by following the instructio
 - Select the Severity Level from the available options.
 - Click Save to save the configuration.
 
-### Configure the Rsyslog server
-You can configure your Rsyslog server to forward your Sophos logs to SEKOIA.IO. Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+### Transport to SEKOIA.IO
+
+Please consult the [Syslog Forwarding](../../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.
+

--- a/docs/xdr/features/collect/integrations/network/watchguard_firebox.md
+++ b/docs/xdr/features/collect/integrations/network/watchguard_firebox.md
@@ -28,7 +28,7 @@ Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a n
 
 ## Transport to SEKOIA.IO
 
-Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation to forward these logs to SEKOIA.IO.
+Please consult the [Rsyslog Transport](../../../ingestion_methods/rsyslog/) documentation or [Syslog Forwarding](../../../../ingestion_methods/sekoiaio_docker_concentrator/) documentation to forward these logs to SEKOIA.IO.
 
 ## Further Readings
 - [Watchguard Firebox Rsyslog Integration Overview](https://www.watchguard.com/help/docs/help-center/en-US/Content/Integration-Guides/General/ubuntu_rsyslog.html)


### PR DESCRIPTION
I suggest replacing, when possible, all redirections to the Rsyslog documentation with the SEKOIA.IO docker concentrator documentation.