### PR TITLE
update(add-link-m365): re-add defender for endpoints

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
           - HarfangLab: xdr/features/collect/integrations/endpoint/harfanglab.md
           - IBM AIX: xdr/features/collect/integrations/endpoint/ibm_aix.md
           - Linux: xdr/features/collect/integrations/endpoint/linux.md
+          - Microsoft Defender For Endpoints: xdr/features/collect/integrations/cloud_and_saas/office365/microsoft_365_defender.md
           - Microsoft Intune: xdr/features/collect/integrations/endpoint/microsoft_intune.md
           - Panda Security Aether: xdr/features/collect/integrations/endpoint/panda_security_aether.md
           - Sekoia.io Endpoint Agent: xdr/features/collect/integrations/endpoint/sekoiaio.md


### PR DESCRIPTION
Add the link for defender for endpoints. The doc is now accessible from the "endpoints" part and also "Cloud and SaaS"