### PR TITLE
Script: make update_mkdocs more resilient against empty taxonomy

### DIFF
--- a/_shared_content/operations_center/integrations/generated/250e4095-fa08-4101-bb02-e72f870fcbd1.md
+++ b/_shared_content/operations_center/integrations/generated/250e4095-fa08-4101-bb02-e72f870fcbd1.md
@@ -894,4 +894,6 @@ The following table lists the fields that are extracted, normalized under the EC
 |`sekoiaio.client.name` | `keyword` | Name of the client |
 |`sekoiaio.server.name` | `keyword` | Name of the server |
 |`sekoiaio.server.os.type` | `keyword` | OS type of the server |
+|`user.target.domain` | `keyword` | Name of the directory the user is a member of. |
+|`user.target.name` | `keyword` | Short name or login of the user. |
 

--- a/_shared_content/operations_center/integrations/generated/2b13307b-7439-4973-900a-2b58303cac90.md
+++ b/_shared_content/operations_center/integrations/generated/2b13307b-7439-4973-900a-2b58303cac90.md
@@ -1168,6 +1168,17 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
 	```
 
 
+=== "test_incident.json"
+
+    ```json
+	
+    {
+        "message": " Event [1201736] [2-3]  (fileName = \"ds:///vmfs/volumes/63985d53-c3598817-6688-5c6f69e18ad0/HDD01-835/HDD01-835.vmdk\", datastore = 'vim.Datastore:d6543eda-9347-4b38-b803-6f5048248ea8:datastore-2809', backingObjectId = \"\", diskMode = \"independent_nonpersistent\", split = <unset>, writeThrough = <unset>, thinProvisioned = false, eagerlyScrub = false, uuid = \"6000C299-dd5c-07cb-b868-3600b53d2781\", contentId = \"5c1d0d8547e8b15283e287f5cb18ef5e\", changeId = <unset>, parent = null, deltaDiskFormat = <unset>, digestEnabled = false, deltaGrainSize = <unset>, deltaDiskFormatVariant = <unset>, sharing = <unset>, keyId = null, cryptoIntegrityProtectionType = <unset>), deltaDiskFormat = \"seSparseFormat\", digestEnabled = false, deltaGrainSize = 4, deltaDiskFormatVariant = <unset>, sharing = \"sharingNone\", keyId = null, cryptoIntegrityProtectionType = <unset>), connectable = null, slotInfo = null, controllerKey = 1000, unitNumber = 3, numaNode = <unset>, capacityInKB = 104857600, capacityInBytes = 107374182400, shar"
+    }
+    	
+	```
+
+
 
 
 

--- a/_shared_content/operations_center/integrations/generated/302065ea-0491-41cf-a472-09b59799c55d.md
+++ b/_shared_content/operations_center/integrations/generated/302065ea-0491-41cf-a472-09b59799c55d.md
@@ -1,0 +1,37 @@
+
+
+
+## Event Samples
+
+Find below few samples of events and how they are normalized by SEKOIA.IO.
+
+
+=== "test_date.json"
+
+    ```json
+	
+    {
+        "message": "{\"@timestamp\": 1674044654}\n",
+        "sekoiaio": {
+            "intake": {
+                "parsing_warnings": [
+                    "No fields extracted from original event"
+                ]
+            }
+        }
+    }
+    	
+	```
+
+
+
+
+
+## Extracted Fields
+
+The following table lists the fields that are extracted, normalized under the ECS format, analyzed and indexed by the parser. It should be noted that infered fields are not listed.
+
+| Name | Type | Description                |
+| ---- | ---- | ---------------------------|
+|`event.start` | `date` | event.start contains the date when the event started or when the activity was first observed. |
+

--- a/_shared_content/operations_center/integrations/generated/3c7057d3-4689-4fae-8033-6f1f887a70f2.md
+++ b/_shared_content/operations_center/integrations/generated/3c7057d3-4689-4fae-8033-6f1f887a70f2.md
@@ -1105,7 +1105,11 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             ]
         },
         "user": {
-            "roles": "Group1,Group2"
+            "roles": "Group1,Group2",
+            "target": {
+                "name": "john.doe$",
+                "domain": "example.org"
+            }
         },
         "action": {
             "properties": {
@@ -1254,6 +1258,11 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
                 "ProcessId": "0x0"
             },
             "id": 4625
+        },
+        "user": {
+            "target": {
+                "name": "ADMINISTRATOR"
+            }
         },
         "related": {
             "hosts": [
@@ -1404,9 +1413,16 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             },
             "id": 5145
         },
+        "user": {
+            "name": "ANONYMOUS LOGON",
+            "domain": "AUTORITE NT"
+        },
         "related": {
             "hosts": [
                 "REDACTED"
+            ],
+            "user": [
+                "ANONYMOUS LOGON"
             ]
         }
     }
@@ -1492,9 +1508,11 @@ The following table lists the fields that are extracted, normalized under the EC
 |`source.ip` | `ip` | IP address of the source. |
 |`source.port` | `long` | Port of the source. |
 |`url.path` | `wildcard` | Path of the request, such as "/search". |
+|`user.domain` | `keyword` | Name of the directory the user is a member of. |
 |`user.id` | `keyword` | Unique identifier of the user. |
 |`user.name` | `keyword` | Short name or login of the user. |
 |`user.roles` | `keyword` | Array of user roles at the time of the event. |
+|`user.target.domain` | `keyword` | Name of the directory the user is a member of. |
 |`user.target.id` | `keyword` | Unique identifier of the user. |
 |`user.target.name` | `keyword` | Short name or login of the user. |
 |`user_agent.original` | `keyword` | Unparsed user_agent string. |

--- a/_shared_content/operations_center/integrations/generated/3e060900-4004-4754-a597-d2944a601930.md
+++ b/_shared_content/operations_center/integrations/generated/3e060900-4004-4754-a597-d2944a601930.md
@@ -18,8 +18,8 @@ In details, the following table denotes the type of events produced by this inte
 | Name | Values |
 | ---- | ------ |
 | Kind | `alert` |
-| Category | `` |
-| Type | `` |
+| Category | `threat` |
+| Type | `indicator` |
 
 
 
@@ -38,6 +38,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "action": "UnauthorizedAccess",
             "kind": "alert",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "severity": 5
         },
         "@timestamp": "2023-03-20T15:33:12.406000Z",
@@ -144,6 +150,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "action": "Exfiltration",
             "kind": "alert",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "severity": 8
         },
         "@timestamp": "2023-03-20T15:33:12.403000Z",
@@ -258,6 +270,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "action": "Execution",
             "kind": "alert",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "severity": 6
         },
         "@timestamp": "2023-03-20T15:33:12.398000Z",
@@ -364,6 +382,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "action": "Execution",
             "kind": "alert",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "severity": 8
         },
         "@timestamp": "2023-03-20T15:33:12.414000Z",
@@ -482,6 +506,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "action": "Policy",
             "kind": "alert",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "severity": 8
         },
         "@timestamp": "2023-03-20T15:33:12.399000Z",
@@ -586,6 +616,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "action": "UnauthorizedAccess",
             "kind": "alert",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "severity": 8
         },
         "@timestamp": "2023-03-20T15:33:12.408000Z",
@@ -686,6 +722,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "action": "Recon",
             "kind": "alert",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "severity": 2
         },
         "@timestamp": "2023-03-20T15:33:12.424000Z",
@@ -816,6 +858,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "action": "UnauthorizedAccess",
             "kind": "alert",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "severity": 5
         },
         "@timestamp": "2023-03-20T15:33:12.406000Z",
@@ -922,6 +970,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "action": "Discovery",
             "kind": "alert",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "severity": 8
         },
         "@timestamp": "2023-03-20T15:33:12.393000Z",
@@ -1073,8 +1127,10 @@ The following table lists the fields that are extracted, normalized under the EC
 |`destination.port` | `long` | Port of the destination. |
 |`error.code` | `keyword` | Error code describing the error. |
 |`event.action` | `keyword` | The action captured by the event. |
+|`event.category` | `keyword` | Event category. The second categorization field in the hierarchy. |
 |`event.kind` | `keyword` | The kind of the event. The highest categorization field in the hierarchy. |
 |`event.severity` | `long` | Numeric severity of the event. |
+|`event.type` | `keyword` | Event type. The third categorization field in the hierarchy. |
 |`network.direction` | `keyword` | Direction of the network traffic. |
 |`network.protocol` | `keyword` | Application protocol name. |
 |`network.transport` | `keyword` | Protocol Name corresponding to the field `iana_number`. |

--- a/_shared_content/operations_center/integrations/generated/40deb162-6bb1-4635-9c99-5c2de7e1d340.md
+++ b/_shared_content/operations_center/integrations/generated/40deb162-6bb1-4635-9c99-5c2de7e1d340.md
@@ -2026,7 +2026,10 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             }
         },
         "user": {
-            "name": "jdoe"
+            "name": "jdoe",
+            "target": {
+                "name": "jdoe"
+            }
         },
         "source": {
             "ip": "83.167.43.106",
@@ -2516,7 +2519,11 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "user": {
             "name": "USER",
             "domain": "-",
-            "id": "S-1-0-0"
+            "id": "S-1-0-0",
+            "target": {
+                "name": "USER",
+                "domain": "-"
+            }
         },
         "source": {
             "ip": "180.163.86.35",
@@ -2722,6 +2729,10 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "name": "john.doe",
             "domain": "WORKGROUP",
             "id": "S-1-5-18",
+            "target": {
+                "name": "john.doe",
+                "domain": "WORKGROUP"
+            },
             "roles": [
                 "admin"
             ]
@@ -4359,6 +4370,7 @@ The following table lists the fields that are extracted, normalized under the EC
 |`deepvisibility.process.parent.counters.file_deletion` | `long` |  |
 |`deepvisibility.process.parent.counters.file_modification` | `long` |  |
 |`deepvisibility.process.parent.counters.module_load` | `long` |  |
+|`deepvisibility.process.parent.counters.net_conn` | `long` |  |
 |`deepvisibility.process.parent.counters.net_conn_in` | `long` |  |
 |`deepvisibility.process.parent.counters.net_conn_out` | `long` |  |
 |`deepvisibility.process.parent.counters.registry_modification` | `long` |  |
@@ -4400,6 +4412,7 @@ The following table lists the fields that are extracted, normalized under the EC
 |`deepvisibility.process.target.counters.file_deletion` | `long` |  |
 |`deepvisibility.process.target.counters.file_modification` | `long` |  |
 |`deepvisibility.process.target.counters.module_load` | `long` |  |
+|`deepvisibility.process.target.counters.net_conn` | `long` |  |
 |`deepvisibility.process.target.counters.net_conn_in` | `long` |  |
 |`deepvisibility.process.target.counters.net_conn_out` | `long` |  |
 |`deepvisibility.process.target.counters.registry_modification` | `long` |  |
@@ -4509,4 +4522,6 @@ The following table lists the fields that are extracted, normalized under the EC
 |`user.id` | `keyword` | Unique identifier of the user. |
 |`user.name` | `keyword` | Short name or login of the user. |
 |`user.roles` | `keyword` | Array of user roles at the time of the event. |
+|`user.target.domain` | `keyword` | Name of the directory the user is a member of. |
+|`user.target.name` | `keyword` | Short name or login of the user. |
 

--- a/_shared_content/operations_center/integrations/generated/6b8cb346-6605-4240-ac15-3828627ba899.md
+++ b/_shared_content/operations_center/integrations/generated/6b8cb346-6605-4240-ac15-3828627ba899.md
@@ -1467,7 +1467,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "action": "Backup/Restore",
             "reason": "Backup ['wab-6.0-cspn_2019-02-04_16-59-11.wbk' saved]",
             "kind": "event",
-            "category": "database",
+            "category": [
+                "database"
+            ],
             "provider": "wabengine"
         },
         "wallix": {
@@ -2519,7 +2521,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "action": "Backup/Restore",
             "reason": "Backup ['wab-6.0-cspn_2019-02-04_16-59-11.wbk' downloaded]",
             "kind": "event",
-            "category": "database",
+            "category": [
+                "database"
+            ],
             "provider": "wabengine"
         },
         "wallix": {
@@ -3580,7 +3584,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "action": "sessionlog",
             "reason": "Current sessions",
             "kind": "event",
-            "category": "authentication",
+            "category": [
+                "authentication"
+            ],
             "type": [
                 "access"
             ],
@@ -3620,7 +3626,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "action": "Backup/Restore",
             "reason": "Backup ['wab-6.0-cspn_2019-02-04_16-59-11.wbk' restored]",
             "kind": "event",
-            "category": "database",
+            "category": [
+                "database"
+            ],
             "provider": "wabengine"
         },
         "wallix": {
@@ -3694,7 +3702,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "reason": "diagnostic [Authentication success: identified with local(LOCAL), authentified with: API key Bastion(APIKEY).]",
             "kind": "event",
-            "category": "authentication"
+            "category": [
+                "authentication"
+            ]
         },
         "wallix": {
             "action": "authentify"
@@ -3728,7 +3738,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "reason": "\"diagnostic [Authentication failed]",
             "kind": "event",
-            "category": "authentication",
+            "category": [
+                "authentication"
+            ],
             "type": [
                 "denied"
             ]
@@ -3766,7 +3778,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "action": "sessionlog",
             "reason": "Closed sessions, Sessionlogs newly terminated",
             "kind": "event",
-            "category": "authentication",
+            "category": [
+                "authentication"
+            ],
             "type": [
                 "access"
             ],
@@ -3805,7 +3819,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "reason": "\"diagnostic [Authentication failed]",
             "kind": "event",
-            "category": "authentication",
+            "category": [
+                "authentication"
+            ],
             "type": [
                 "denied"
             ]

--- a/_shared_content/operations_center/integrations/generated/8a9894f8-d7bc-4c06-b96a-8808b3c6cade.md
+++ b/_shared_content/operations_center/integrations/generated/8a9894f8-d7bc-4c06-b96a-8808b3c6cade.md
@@ -41,7 +41,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "type": [
                 "change"
             ],
-            "category": "configuration"
+            "category": [
+                "configuration"
+            ]
         },
         "observer": {
             "vendor": "Cisco",
@@ -102,7 +104,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "type": [
                 "info"
             ],
-            "category": "network",
+            "category": [
+                "network"
+            ],
             "reason": "MnT purge event occurred"
         },
         "observer": {
@@ -132,7 +136,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "type": [
                 "info"
             ],
-            "category": "network",
+            "category": [
+                "network"
+            ],
             "reason": ": ACTIVE_DIRECTORY_DIAGNOSTIC_TOOL_ISSUES_FOUND need to complete"
         },
         "observer": {
@@ -155,7 +161,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "type": [
                 "info"
             ],
-            "category": "network"
+            "category": [
+                "network"
+            ]
         },
         "observer": {
             "vendor": "Cisco",
@@ -191,7 +199,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "type": [
                 "info"
             ],
-            "category": "network"
+            "category": [
+                "network"
+            ]
         },
         "observer": {
             "vendor": "Cisco",
@@ -232,7 +242,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "type": [
                 "info"
             ],
-            "category": "network",
+            "category": [
+                "network"
+            ],
             "reason": "Request timed out."
         },
         "observer": {
@@ -275,7 +287,9 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "type": [
                 "info"
             ],
-            "category": "network"
+            "category": [
+                "network"
+            ]
         },
         "observer": {
             "vendor": "Cisco",

--- a/_shared_content/operations_center/integrations/generated/98fa7079-41ae-4033-a93f-bbd70d114188.md
+++ b/_shared_content/operations_center/integrations/generated/98fa7079-41ae-4033-a93f-bbd70d114188.md
@@ -1,0 +1,663 @@
+
+## Event Categories
+
+
+The following table lists the data source offered by this integration.
+
+| Data Source | Description                          |
+| ----------- | ------------------------------------ |
+| `DNS records` | Darktrace monitors DNS requests or connections from devices to watched domains or IP addresses. |
+| `Web logs` | Darktrace monitors accesses to watched domains. |
+
+
+
+
+
+In details, the following table denotes the type of events produced by this integration.
+
+| Name | Values |
+| ---- | ------ |
+| Kind | `alert`, `event` |
+| Category | `network` |
+| Type | `info` |
+
+
+
+
+## Event Samples
+
+Find below few samples of events and how they are normalized by SEKOIA.IO.
+
+
+=== "test_anomalous_file.json"
+
+    ```json
+	
+    {
+        "message": "{\"commentCount\":0,\"pbid\":26316,\"time\":1687967502000,\"creationTime\":1687967508000,\"model\":{\"then\":{\"name\":\"AnomalousFile::ZiporGzipfromRareExternalLocation\",\"pid\":619,\"phid\":9945,\"uuid\":\"80010119-6d7f-0000-0305-5e0000000172\",\"logic\":{\"data\":[19046],\"type\":\"componentList\",\"version\":1},\"throttle\":3600,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[\"\",\"AP:Tooling\",\"OTEngineer\"],\"interval\":0,\"delay\":0,\"sequenced\":false,\"active\":true,\"modified\":\"2023-06-28 11:53:50\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"AdevicehasdownloadedaZIPfilefromalocationthatthenetworkdoesnotnormallyvisit.\\n\\nAction:Reviewthefile,itshashandthesourcetoensurethatthisfileisrequiredwithinthenetworkforbusinesspurposes.\",\"behaviour\":\"decreasing\",\"created\":{\"by\":\"System\"},\"edited\":{\"by\":\"System\"},\"version\":42,\"mitre\":{\"tactics\":[\"resource-development\"],\"techniques\":[\"T1588.001\"]},\"priority\":1,\"category\":\"Informational\",\"compliance\":false},\"now\":{\"name\":\"AnomalousFile::ZiporGzipfromRareExternalLocation\",\"pid\":619,\"phid\":9945,\"uuid\":\"80010119-6d7f-0000-0305-5e0000000172\",\"logic\":{\"data\":[19046],\"type\":\"componentList\",\"version\":1},\"throttle\":3600,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[\"\",\"AP:Tooling\",\"OTEngineer\"],\"interval\":0,\"delay\":0,\"sequenced\":false,\"active\":true,\"modified\":\"2023-06-28 11:53:50\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"AdevicehasdownloadedaZIPfilefromalocationthatthenetworkdoesnotnormallyvisit.\\n\\nAction:Reviewthefile,itshashandthesourcetoensurethatthisfileisrequiredwithinthenetworkforbusinesspurposes.\",\"behaviour\":\"decreasing\",\"created\":{\"by\":\"System\"},\"edited\":{\"by\":\"System\"},\"message\":\"Excludedcommonuseragents\",\"version\":42,\"mitre\":{\"tactics\":[\"resource-development\"],\"techniques\":[\"T1588.001\"]},\"priority\":1,\"category\":\"Informational\",\"compliance\":false}},\"triggeredComponents\":[{\"time\":1687967501000,\"cbid\":26393,\"cid\":19046,\"chid\":30682,\"size\":1,\"threshold\":0,\"interval\":3600,\"logic\":{\"data\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":{\"left\":\"I\",\"operator\":\"AND\",\"right\":{\"left\":\"J\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"Q\",\"operator\":\"AND\",\"right\":{\"left\":\"R\",\"operator\":\"AND\",\"right\":{\"left\":\"T\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"W\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":{\"left\":\"I\",\"operator\":\"AND\",\"right\":{\"left\":\"J\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"Q\",\"operator\":\"AND\",\"right\":{\"left\":\"R\",\"operator\":\"AND\",\"right\":{\"left\":\"T\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"W\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":{\"left\":\"G\",\"operator\":\"AND\",\"right\":{\"left\":\"I\",\"operator\":\"AND\",\"right\":{\"left\":\"J\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"Q\",\"operator\":\"AND\",\"right\":{\"left\":\"R\",\"operator\":\"AND\",\"right\":{\"left\":\"T\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"W\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":{\"left\":\"I\",\"operator\":\"AND\",\"right\":{\"left\":\"J\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"Q\",\"operator\":\"AND\",\"right\":{\"left\":\"R\",\"operator\":\"AND\",\"right\":{\"left\":\"T\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"W\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":{\"left\":\"K\",\"operator\":\"AND\",\"right\":{\"left\":\"L\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"Q\",\"operator\":\"AND\",\"right\":{\"left\":\"S\",\"operator\":\"AND\",\"right\":{\"left\":\"T\",\"operator\":\"AND\",\"right\":{\"left\":\"U\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"W\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":{\"left\":\"K\",\"operator\":\"AND\",\"right\":{\"left\":\"L\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"Q\",\"operator\":\"AND\",\"right\":{\"left\":\"S\",\"operator\":\"AND\",\"right\":{\"left\":\"T\",\"operator\":\"AND\",\"right\":{\"left\":\"U\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"W\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":{\"left\":\"G\",\"operator\":\"AND\",\"right\":{\"left\":\"K\",\"operator\":\"AND\",\"right\":{\"left\":\"L\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"Q\",\"operator\":\"AND\",\"right\":{\"left\":\"S\",\"operator\":\"AND\",\"right\":{\"left\":\"T\",\"operator\":\"AND\",\"right\":{\"left\":\"U\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"W\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}}},\"operator\":\"OR\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":{\"left\":\"K\",\"operator\":\"AND\",\"right\":{\"left\":\"L\",\"operator\":\"AND\",\"right\":{\"left\":\"M\",\"operator\":\"AND\",\"right\":{\"left\":\"N\",\"operator\":\"AND\",\"right\":{\"left\":\"O\",\"operator\":\"AND\",\"right\":{\"left\":\"P\",\"operator\":\"AND\",\"right\":{\"left\":\"Q\",\"operator\":\"AND\",\"right\":{\"left\":\"S\",\"operator\":\"AND\",\"right\":{\"left\":\"T\",\"operator\":\"AND\",\"right\":{\"left\":\"U\",\"operator\":\"AND\",\"right\":{\"left\":\"V\",\"operator\":\"AND\",\"right\":{\"left\":\"W\",\"operator\":\"AND\",\"right\":{\"left\":\"Y\",\"operator\":\"AND\",\"right\":\"Z\"}}}}}}}}}}}}}}}}}}}}}}},\"version\":\"v0.1\"},\"ip\":\"104.18.103.100/32\",\"port\":80,\"metric\":{\"mlid\":1,\"name\":\"externalconnections\",\"label\":\"ExternalConnections\"},\"triggeredFilters\":[{\"cfid\":232424,\"id\":\"C\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{\"value\":\"3\"},\"comparatorType\":\"isnot\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":232426,\"id\":\"F\",\"filterType\":\"Direction\",\"arguments\":{\"value\":\"out\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"out\"}},{\"cfid\":232428,\"id\":\"H\",\"filterType\":\"HTTPcontenttype\",\"arguments\":{\"value\":\"application/x-gzip\"},\"comparatorType\":\"matches\",\"trigger\":{\"value\":\"application/x-gzip\"}},{\"cfid\":232430,\"id\":\"J\",\"filterType\":\"RareexternalIP\",\"arguments\":{\"value\":98},\"comparatorType\":\">=\",\"trigger\":{\"value\":\"100\"}},{\"cfid\":232431,\"id\":\"K\",\"filterType\":\"Raredomain\",\"arguments\":{\"value\":95},\"comparatorType\":\">=\",\"trigger\":{\"value\":\"100\"}},{\"cfid\":232432,\"id\":\"L\",\"filterType\":\"Trustedhostname\",\"arguments\":{\"value\":\"false\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"false\"}},{\"cfid\":232433,\"id\":\"M\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{\"value\":\"9\"},\"comparatorType\":\"isnot\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":232434,\"id\":\"N\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{\"value\":\"4\"},\"comparatorType\":\"isnot\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":232435,\"id\":\"O\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{\"value\":\"13\"},\"comparatorType\":\"isnot\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":232436,\"id\":\"P\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{\"value\":\"17\"},\"comparatorType\":\"isnot\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":232437,\"id\":\"Q\",\"filterType\":\"Taggedinternalsource\",\"arguments\":{\"value\":15},\"comparatorType\":\"doesnothavetag\",\"trigger\":{\"value\":\"15\",\"tag\":{\"tid\":15,\"expiry\":0,\"thid\":15,\"name\":\"ConflictingUser-Agents\",\"restricted\":false,\"data\":{\"auto\":false,\"color\":284,\"description\":\"\",\"visibility\":\"Public\"},\"isReferenced\":true}}},{\"cfid\":232438,\"id\":\"R\",\"filterType\":\"DestinationIP\",\"arguments\":{\"value\":\"0.0.0.0\"},\"comparatorType\":\"doesnotmatch\",\"trigger\":{\"value\":\"104.18.103.100\"}},{\"cfid\":232439,\"id\":\"S\",\"filterType\":\"Connectionhostname\",\"arguments\":{\"value\":\"(speed(test|check).+|.+speed(test|check).+)|.*((up(date|grade)|download|content|mirrors|weather|changes|quant|ctldl|avupdate).*\\\\.(carbonblack\\\\.io|nutanix\\\\.com|pandasoftware\\\\.com|ivanti\\\\.com|mit\\\\.edu|mastercam\\\\.com|rit\\\\.edu|knime\\\\.com|logicnow\\\\.us|oppomobile\\\\.com|trendmicro\\\\.com|panorama9\\\\.com|jiransecurity\\\\.com|refinitiv\\\\.com|jiran\\\\.com|loxtop\\\\.com|snoopwall\\\\.com|tumbleweed\\\\.com|sangfor\\\\.net|alyac\\\\.com|spamassassin\\\\.org|verein-clean\\\\.net|itsupport247\\\\.net|lsfilter\\\\.com|iboss\\\\.com|eeye\\\\.com|windowsupdate\\\\.com|fireeye\\\\.com)|definitionsbd\\\\.adaware\\\\.com|nasepm\\\\.aramark\\\\.com|(bdefs|hw|ec)\\\\.threattrack\\\\.com|upd\\\\.zonelabs\\\\.com|www\\\\.solutionsam\\\\.com|licensingservice\\\\.altarix\\\\.com|autoupdate\\\\.bradyid\\\\.com|iblocklist\\\\.com|clientservices\\\\.googleapis\\\\.com|mirror\\\\.centos\\\\..*\\\\.serverforge\\\\.org|sync\\\\.bigfix\\\\.com|catalog\\\\.kace\\\\.com)\"},\"comparatorType\":\"doesnotmatchregularexpression\",\"trigger\":{\"value\":\"kali.download\"}},{\"cfid\":232440,\"id\":\"T\",\"filterType\":\"Useragent\",\"arguments\":{\"value\":\"/((libdnf|sa-update|Valve\\\\/Steam|itunesstored|pfSense|McAfee|DebianAPT-HTTP).*|Sylink|.*LANguard.*|Smc|SG\\\\_CTAVUpdater|NetpasUpdater|urlgrabber/[0-9.]+yum/[0-9.]+|ManageEngine(Endpoint|Desktop)Central).*/i\"},\"comparatorType\":\"doesnotmatchregularexpression\",\"trigger\":{\"value\":\"\"}},{\"cfid\":232441,\"id\":\"U\",\"filterType\":\"Connectionhostname\",\"arguments\":{\"value\":\"(antivirus|rpm(s)?|sa-update|centos|fedora).*\"},\"comparatorType\":\"doesnotmatchregularexpression\",\"trigger\":{\"value\":\"kali.download\"}},{\"cfid\":232442,\"id\":\"V\",\"filterType\":\"URI\",\"arguments\":{\"value\":\"/.*\\\\/centos\\\\/.*\\\\.xml\\\\.gz/i\"},\"comparatorType\":\"doesnotmatchregularexpression\",\"trigger\":{\"value\":\"/kali/dists/kali-rolling/non-free/binary-amd64/Packages.gz\"}},{\"cfid\":232443,\"id\":\"W\",\"filterType\":\"URI\",\"arguments\":{\"value\":\"dl.delivery.mp.microsoft.com\"},\"comparatorType\":\"doesnotcontain\",\"trigger\":{\"value\":\"/kali/dists/kali-rolling/non-free/binary-amd64/Packages.gz\"}},{\"cfid\":232444,\"id\":\"Y\",\"filterType\":\"HTTPresponsecode\",\"arguments\":{\"value\":400},\"comparatorType\":\"<\",\"trigger\":{\"value\":\"200\"}},{\"cfid\":232445,\"id\":\"Z\",\"filterType\":\"Individualsizedown\",\"arguments\":{\"value\":10000},\"comparatorType\":\">=\",\"trigger\":{\"value\":\"60493165\"}},{\"cfid\":232446,\"id\":\"d1\",\"filterType\":\"Individualsizedown\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"60493165\"}},{\"cfid\":232447,\"id\":\"d10\",\"filterType\":\"Individualsizeup\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"679\"}},{\"cfid\":232448,\"id\":\"d11\",\"filterType\":\"HTTPreferrer\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":232449,\"id\":\"d12\",\"filterType\":\"HTTPmethod\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":232450,\"id\":\"d13\",\"filterType\":\"Dataratio\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"0\"}},{\"cfid\":232451,\"id\":\"d14\",\"filterType\":\"Ageofdestination\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"43965774\"}},{\"cfid\":232452,\"id\":\"d2\",\"filterType\":\"HTTPresponsecode\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"200\"}},{\"cfid\":232453,\"id\":\"d3\",\"filterType\":\"Useragent\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":232454,\"id\":\"d4\",\"filterType\":\"ASN\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"AS13335CLOUDFLARENET\"}},{\"cfid\":232455,\"id\":\"d5\",\"filterType\":\"URI\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"/kali/dists/kali-rolling/non-free/binary-amd64/Packages.gz\"}},{\"cfid\":232456,\"id\":\"d6\",\"filterType\":\"DestinationIP\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"104.18.103.100\"}},{\"cfid\":232457,\"id\":\"d7\",\"filterType\":\"Connectionhostname\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"kali.download\"}},{\"cfid\":232458,\"id\":\"d8\",\"filterType\":\"HTTPcontenttype\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"application/x-gzip\"}},{\"cfid\":232459,\"id\":\"d9\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"6\"}}]}],\"score\":0.245,\"device\":{\"did\":16,\"ip\":\"192.168.1.#18408\",\"ips\":[{\"ip\":\"192.168.1.#18408\",\"timems\":1688263200000,\"time\":\"2023-07-0202:00:00\",\"sid\":3}],\"sid\":3,\"firstSeen\":1644001727000,\"lastSeen\":1688266122000,\"typename\":\"desktop\",\"typelabel\":\"Desktop\"}}",
+        "event": {
+            "category": "network",
+            "end": "2023-06-28T11:53:50Z",
+            "kind": "alert",
+            "type": [
+                "info"
+            ]
+        },
+        "@timestamp": "2023-06-28T15:51:42Z",
+        "host": {
+            "id": "16",
+            "ip": []
+        },
+        "observer": {
+            "name": "Darktrace",
+            "product": "Threat visualizer"
+        },
+        "darktrace": {
+            "threat_visualizer": {
+                "creationTime": 1687967508000,
+                "commentCount": 0,
+                "pbid": 26316,
+                "time": 1687967502000,
+                "model": {
+                    "then": {
+                        "name": "AnomalousFile::ZiporGzipfromRareExternalLocation",
+                        "pid": 619,
+                        "phid": 9945,
+                        "uuid": "80010119-6d7f-0000-0305-5e0000000172",
+                        "mitre": {
+                            "tactics": [
+                                "resource-development"
+                            ],
+                            "techniques": [
+                                "T1588.001"
+                            ]
+                        },
+                        "tags": [
+                            "",
+                            "AP:Tooling",
+                            "OTEngineer"
+                        ],
+                        "description": "AdevicehasdownloadedaZIPfilefromalocationthatthenetworkdoesnotnormallyvisit.\n\nAction:Reviewthefile,itshashandthesourcetoensurethatthisfileisrequiredwithinthenetworkforbusinesspurposes.",
+                        "category": "Informational",
+                        "priority": 1,
+                        "behaviour": "decreasing",
+                        "version": 42
+                    },
+                    "now": {
+                        "name": "AnomalousFile::ZiporGzipfromRareExternalLocation",
+                        "pid": 619,
+                        "phid": 9945,
+                        "uuid": "80010119-6d7f-0000-0305-5e0000000172",
+                        "mitre": {
+                            "tactics": [
+                                "resource-development"
+                            ],
+                            "techniques": [
+                                "T1588.001"
+                            ]
+                        },
+                        "tags": [
+                            "",
+                            "AP:Tooling",
+                            "OTEngineer"
+                        ],
+                        "description": "AdevicehasdownloadedaZIPfilefromalocationthatthenetworkdoesnotnormallyvisit.\n\nAction:Reviewthefile,itshashandthesourcetoensurethatthisfileisrequiredwithinthenetworkforbusinesspurposes.",
+                        "behaviour": "decreasing",
+                        "message": "Excludedcommonuseragents",
+                        "priority": 1,
+                        "category": "Informational",
+                        "version": 42
+                    }
+                },
+                "score": 0.245,
+                "device": {
+                    "ip": "192.168.1.#18408",
+                    "ips": [
+                        {
+                            "ip": "192.168.1.#18408",
+                            "timems": 1688263200000,
+                            "time": "2023-07-0202:00:00",
+                            "sid": 3
+                        }
+                    ],
+                    "sid": 3,
+                    "firstSeen": 1644001727000,
+                    "lastSeen": 1688266122000,
+                    "typename": "desktop",
+                    "typelabel": "Desktop"
+                }
+            }
+        },
+        "related": {
+            "ip": []
+        }
+    }
+    	
+	```
+
+
+=== "test_antigena_connection.json"
+
+    ```json
+	
+    {
+        "message": "{\"commentCount\":0,\"pbid\":26368,\"time\":1687987886000,\"creationTime\":1687987892000,\"model\":{\"then\":{\"name\":\"Antigena::Network::Compliance::AntigenaConnectionSeen\",\"pid\":2299,\"phid\":9961,\"uuid\":\"5f78deda-3ff9-445f-a88e-2137dca625d6\",\"logic\":{\"data\":[19083],\"type\":\"componentList\",\"version\":1},\"throttle\":3600,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{\"action\":\"quarantine\",\"confirm\":true,\"connector_actions\":{},\"duration\":1000,\"ignoreSchedule\":true,\"threshold\":\"50\"},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[],\"interval\":3600,\"delay\":0,\"sequenced\":true,\"active\":true,\"modified\":\"2023-06-28 21:31:29\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":false,\"autoSuppress\":false,\"description\":\"\",\"behaviour\":\"decreasing\",\"defeats\":[],\"created\":{\"by\":\"darktrace\",\"userID\":2},\"edited\":{\"by\":\"darktrace\",\"userID\":2},\"version\":7,\"priority\":4,\"category\":\"Suspicious\",\"compliance\":true},\"now\":{\"name\":\"Antigena::Network::Compliance::AntigenaConnectionSeen\",\"pid\":2299,\"phid\":9962,\"uuid\":\"5f78deda-3ff9-445f-a88e-2137dca625d6\",\"logic\":{\"data\":[19084],\"type\":\"componentList\",\"version\":1},\"throttle\":3600,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{\"action\":\"quarantine\",\"confirm\":true,\"connector_actions\":{},\"duration\":1000,\"ignoreSchedule\":true,\"threshold\":\"50\"},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[],\"interval\":3600,\"delay\":0,\"sequenced\":true,\"active\":false,\"modified\":\"2023-06-28 21:32:10\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":false,\"autoSuppress\":false,\"description\":\"\",\"behaviour\":\"decreasing\",\"defeats\":[],\"created\":{\"by\":\"darktrace\",\"userID\":2},\"edited\":{\"by\":\"darktrace\",\"userID\":2},\"version\":8,\"priority\":4,\"category\":\"Suspicious\",\"compliance\":true}},\"triggeredComponents\":[{\"time\":1687987885000,\"cbid\":26445,\"cid\":19083,\"chid\":30726,\"size\":1,\"threshold\":0,\"interval\":3600,\"logic\":{\"data\":{},\"version\":\"v0.1\"},\"ip\":\"192.168.16.100/32\",\"port\":443,\"metric\":{\"mlid\":16,\"name\":\"connections\",\"label\":\"Connections\"},\"triggeredFilters\":[]}],\"score\":0.871,\"device\":{\"did\":31,\"vendor\":\"\",\"ip\":\"192.168.1.2\",\"ips\":[{\"ip\":\"192.168.1.2\",\"timems\":1688389200000,\"time\":\"2023-07-0313:00:00\",\"sid\":3}],\"sid\":3,\"firstSeen\":1649669953000,\"lastSeen\":1688391406000,\"typename\":\"dnsserver\",\"typelabel\":\"DNSServer\"}}",
+        "event": {
+            "category": "network",
+            "end": "2023-06-28T21:31:29Z",
+            "kind": "alert",
+            "type": [
+                "info"
+            ]
+        },
+        "@timestamp": "2023-06-28T21:31:26Z",
+        "host": {
+            "id": "31",
+            "ip": [
+                "192.168.1.2"
+            ]
+        },
+        "observer": {
+            "name": "Darktrace",
+            "product": "Threat visualizer"
+        },
+        "darktrace": {
+            "threat_visualizer": {
+                "creationTime": 1687987892000,
+                "commentCount": 0,
+                "pbid": 26368,
+                "time": 1687987886000,
+                "model": {
+                    "then": {
+                        "name": "Antigena::Network::Compliance::AntigenaConnectionSeen",
+                        "pid": 2299,
+                        "phid": 9961,
+                        "uuid": "5f78deda-3ff9-445f-a88e-2137dca625d6",
+                        "tags": [],
+                        "category": "Suspicious",
+                        "priority": 4,
+                        "behaviour": "decreasing",
+                        "defeats": [],
+                        "version": 7
+                    },
+                    "now": {
+                        "name": "Antigena::Network::Compliance::AntigenaConnectionSeen",
+                        "pid": 2299,
+                        "phid": 9962,
+                        "uuid": "5f78deda-3ff9-445f-a88e-2137dca625d6",
+                        "tags": [],
+                        "behaviour": "decreasing",
+                        "defeats": [],
+                        "edited": {
+                            "userID": 2
+                        },
+                        "priority": 4,
+                        "category": "Suspicious",
+                        "version": 8
+                    }
+                },
+                "score": 0.871,
+                "device": {
+                    "ip": "192.168.1.2",
+                    "ips": [
+                        {
+                            "ip": "192.168.1.2",
+                            "timems": 1688389200000,
+                            "time": "2023-07-0313:00:00",
+                            "sid": 3
+                        }
+                    ],
+                    "sid": 3,
+                    "firstSeen": 1649669953000,
+                    "lastSeen": 1688391406000,
+                    "typename": "dnsserver",
+                    "typelabel": "DNSServer"
+                }
+            }
+        },
+        "related": {
+            "ip": [
+                "192.168.1.2"
+            ]
+        }
+    }
+    	
+	```
+
+
+=== "test_device_attack_and_recon_tools.json"
+
+    ```json
+	
+    {
+        "message": "{\"commentCount\":0,\"pbid\":27103,\"time\":1688266123000,\"creationTime\":1688266130000,\"model\":{\"then\":{\"name\":\"Device::AttackandReconTools\",\"pid\":76,\"phid\":8953,\"uuid\":\"80010119-6d7f-0000-0305-5e0000000197\",\"logic\":{\"data\":[{\"cid\":17299,\"weight\":1},{\"cid\":17302,\"weight\":1},{\"cid\":17298,\"weight\":1},{\"cid\":17300,\"weight\":1},{\"cid\":17301,\"weight\":1},{\"cid\":17303,\"weight\":1},{\"cid\":17304,\"weight\":1}],\"targetScore\":1,\"type\":\"weightedComponentList\",\"version\":1},\"throttle\":604800,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[\"\",\"AP:InternalRecon\",\"OTEngineer\"],\"interval\":3600,\"delay\":0,\"sequenced\":false,\"active\":true,\"modified\":\"2023-03-14 12:53:21\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"Adeviceisusingcommonpenetrationtestingtools.\\n\\nAction:Reviewthedevicetoseeifitasecuritydevice,thesecanbetaggedassuchtoexcludethemfromfuturebreaches.Activityfromnonsecuritydevicesmeritfurtherinvestigationintowhatelsethedeviceisdoingandcouldbeasignificantriskwithinthenetwork.\",\"behaviour\":\"decreasing\",\"created\":{\"by\":\"System\"},\"edited\":{\"by\":\"System\"},\"version\":87,\"mitre\":{\"tactics\":[\"initial-access\"],\"techniques\":[\"T1200\"]},\"priority\":4,\"category\":\"Suspicious\",\"compliance\":false},\"now\":{\"name\":\"Device::AttackandReconTools\",\"pid\":76,\"phid\":8953,\"uuid\":\"80010119-6d7f-0000-0305-5e0000000197\",\"logic\":{\"data\":[{\"cid\":17299,\"weight\":1},{\"cid\":17302,\"weight\":1},{\"cid\":17298,\"weight\":1},{\"cid\":17300,\"weight\":1},{\"cid\":17301,\"weight\":1},{\"cid\":17303,\"weight\":1},{\"cid\":17304,\"weight\":1}],\"targetScore\":1,\"type\":\"weightedComponentList\",\"version\":1},\"throttle\":604800,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[\"\",\"AP:InternalRecon\",\"OTEngineer\"],\"interval\":3600,\"delay\":0,\"sequenced\":false,\"active\":true,\"modified\":\"2023-03-14 12:53:21\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"Adeviceisusingcommonpenetrationtestingtools.\\n\\nAction:Reviewthedevicetoseeifitasecuritydevice,thesecanbetaggedassuchtoexcludethemfromfuturebreaches.Activityfromnonsecuritydevicesmeritfurtherinvestigationintowhatelsethedeviceisdoingandcouldbeasignificantriskwithinthenetwork.\",\"behaviour\":\"decreasing\",\"created\":{\"by\":\"System\"},\"edited\":{\"by\":\"System\"},\"message\":\"Addeddetectionforgobusteranddirbuster\",\"version\":87,\"mitre\":{\"tactics\":[\"initial-access\"],\"techniques\":[\"T1200\"]},\"priority\":4,\"category\":\"Suspicious\",\"compliance\":false}},\"triggeredComponents\":[{\"time\":1688266122000,\"cbid\":27180,\"cid\":17302,\"chid\":27905,\"size\":1,\"threshold\":0,\"interval\":3600,\"logic\":{\"data\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":\"J\"}}}}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":\"H\"}}}}},\"operator\":\"OR\",\"right\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":{\"left\":\"G\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":\"I\"}}}}}}}},\"version\":\"v0.1\"},\"ip\":\"192.168.1.2/32\",\"port\":53,\"metric\":{\"mlid\":11,\"name\":\"dnsrequests\",\"label\":\"DNSRequests\"},\"triggeredFilters\":[{\"cfid\":208828,\"id\":\"A\",\"filterType\":\"DNShostlookup\",\"arguments\":{\"value\":\"kali(\\\\..+)?\"},\"comparatorType\":\"matchesregularexpression\",\"trigger\":{\"value\":\"kali.download\"}},{\"cfid\":208829,\"id\":\"B\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{\"value\":\"12\"},\"comparatorType\":\"isnot\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":208830,\"id\":\"C\",\"filterType\":\"Taggedinternalsource\",\"arguments\":{\"value\":18},\"comparatorType\":\"doesnothavetag\",\"trigger\":{\"value\":\"18\",\"tag\":{\"tid\":18,\"expiry\":0,\"thid\":18,\"name\":\"DNSServer\",\"restricted\":false,\"data\":{\"auto\":false,\"color\":112,\"description\":\"DevicesreceivingandmakingDNSqueries\",\"visibility\":\"Public\"},\"isReferenced\":true}}},{\"cfid\":208831,\"id\":\"D\",\"filterType\":\"Direction\",\"arguments\":{\"value\":\"out\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"out\"}},{\"cfid\":208832,\"id\":\"E\",\"filterType\":\"Taggedinternalsource\",\"arguments\":{\"value\":4},\"comparatorType\":\"doesnothavetag\",\"trigger\":{\"value\":\"4\",\"tag\":{\"tid\":4,\"expiry\":0,\"thid\":4,\"name\":\"SecurityDevice\",\"restricted\":false,\"data\":{\"auto\":false,\"color\":55,\"description\":\"\",\"visibility\":\"Public\"},\"isReferenced\":true}}},{\"cfid\":208835,\"id\":\"H\",\"filterType\":\"Taggedinternalsource\",\"arguments\":{\"value\":58},\"comparatorType\":\"doesnothavetag\",\"trigger\":{\"value\":\"58\",\"tag\":{\"tid\":58,\"expiry\":0,\"thid\":58,\"name\":\"MailServer\",\"restricted\":false,\"data\":{\"auto\":false,\"color\":200,\"description\":\"\"},\"isReferenced\":true}}},{\"cfid\":208836,\"id\":\"I\",\"filterType\":\"DNShostlookup\",\"arguments\":{\"value\":\"backbox.com\"},\"comparatorType\":\"doesnotmatch\",\"trigger\":{\"value\":\"kali.download\"}},{\"cfid\":208837,\"id\":\"J\",\"filterType\":\"DNShostlookup\",\"arguments\":{\"value\":\"^kali\\\\.(by|hu|hr|cheng-tsui\\\\.com|tradair\\\\.com)$\"},\"comparatorType\":\"doesnotmatchregularexpression\",\"trigger\":{\"value\":\"kali.download\"}},{\"cfid\":208838,\"id\":\"d1\",\"filterType\":\"DNShostlookup\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"kali.download\"}}]}],\"score\":0.871,\"device\":{\"did\":16,\"ip\":\"192.168.1.#18408\",\"ips\":[{\"ip\":\"192.168.1.#18408\",\"timems\":1688263200000,\"time\":\"2023-07-0202:00:00\",\"sid\":3}],\"sid\":3,\"firstSeen\":1644001727000,\"lastSeen\":1688266122000,\"typename\":\"desktop\",\"typelabel\":\"Desktop\"}}",
+        "event": {
+            "category": "network",
+            "end": "2023-03-14T12:53:21Z",
+            "kind": "alert",
+            "type": [
+                "info"
+            ]
+        },
+        "@timestamp": "2023-07-02T02:48:43Z",
+        "host": {
+            "id": "16",
+            "ip": []
+        },
+        "observer": {
+            "name": "Darktrace",
+            "product": "Threat visualizer"
+        },
+        "darktrace": {
+            "threat_visualizer": {
+                "creationTime": 1688266130000,
+                "commentCount": 0,
+                "pbid": 27103,
+                "time": 1688266123000,
+                "model": {
+                    "then": {
+                        "name": "Device::AttackandReconTools",
+                        "pid": 76,
+                        "phid": 8953,
+                        "uuid": "80010119-6d7f-0000-0305-5e0000000197",
+                        "mitre": {
+                            "tactics": [
+                                "initial-access"
+                            ],
+                            "techniques": [
+                                "T1200"
+                            ]
+                        },
+                        "tags": [
+                            "",
+                            "AP:InternalRecon",
+                            "OTEngineer"
+                        ],
+                        "description": "Adeviceisusingcommonpenetrationtestingtools.\n\nAction:Reviewthedevicetoseeifitasecuritydevice,thesecanbetaggedassuchtoexcludethemfromfuturebreaches.Activityfromnonsecuritydevicesmeritfurtherinvestigationintowhatelsethedeviceisdoingandcouldbeasignificantriskwithinthenetwork.",
+                        "category": "Suspicious",
+                        "priority": 4,
+                        "behaviour": "decreasing",
+                        "version": 87
+                    },
+                    "now": {
+                        "name": "Device::AttackandReconTools",
+                        "pid": 76,
+                        "phid": 8953,
+                        "uuid": "80010119-6d7f-0000-0305-5e0000000197",
+                        "mitre": {
+                            "tactics": [
+                                "initial-access"
+                            ],
+                            "techniques": [
+                                "T1200"
+                            ]
+                        },
+                        "tags": [
+                            "",
+                            "AP:InternalRecon",
+                            "OTEngineer"
+                        ],
+                        "description": "Adeviceisusingcommonpenetrationtestingtools.\n\nAction:Reviewthedevicetoseeifitasecuritydevice,thesecanbetaggedassuchtoexcludethemfromfuturebreaches.Activityfromnonsecuritydevicesmeritfurtherinvestigationintowhatelsethedeviceisdoingandcouldbeasignificantriskwithinthenetwork.",
+                        "behaviour": "decreasing",
+                        "message": "Addeddetectionforgobusteranddirbuster",
+                        "priority": 4,
+                        "category": "Suspicious",
+                        "version": 87
+                    }
+                },
+                "score": 0.871,
+                "device": {
+                    "ip": "192.168.1.#18408",
+                    "ips": [
+                        {
+                            "ip": "192.168.1.#18408",
+                            "timems": 1688263200000,
+                            "time": "2023-07-0202:00:00",
+                            "sid": 3
+                        }
+                    ],
+                    "sid": 3,
+                    "firstSeen": 1644001727000,
+                    "lastSeen": 1688266122000,
+                    "typename": "desktop",
+                    "typelabel": "Desktop"
+                }
+            }
+        },
+        "related": {
+            "ip": []
+        }
+    }
+    	
+	```
+
+
+=== "test_device_request_watched_domain.json"
+
+    ```json
+	
+    {
+        "message": "{\"commentCount\":0,\"pbid\":25808,\"time\":1687774142000,\"creationTime\":1687774148000,\"model\":{\"then\":{\"name\":\"Compromise::WatchedDomain\",\"pid\":608,\"phid\":6768,\"uuid\":\"80010119-6d7f-0000-0305-5e0000000256\",\"logic\":{\"data\":[{\"cid\":13112,\"weight\":1},{\"cid\":13114,\"weight\":1},{\"cid\":13115,\"weight\":1},{\"cid\":13113,\"weight\":1}],\"targetScore\":1,\"type\":\"weightedComponentList\",\"version\":1},\"throttle\":3600,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[\"\",\"AP:C2Comms\"],\"interval\":3600,\"delay\":0,\"sequenced\":false,\"active\":true,\"modified\":\"2022-06-22 15:56:27\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"AdeviceisobservedmakingDNSrequestsorconnectionstowatcheddomainsorIPaddresses.ThewatchlistcanbeeditedfromthemainGUImenu,Intelsub-menu,undertheiconWatchedDomains.\\n\\nAction:ReviewthedomainandIPbeingconnectedto.\",\"behaviour\":\"decreasing\",\"defeats\":[],\"created\":{\"by\":\"System\"},\"edited\":{\"by\":\"System\"},\"version\":31,\"priority\":5,\"category\":\"Critical\",\"compliance\":false},\"now\":{\"name\":\"Compromise::WatchedDomain\",\"pid\":608,\"phid\":6768,\"uuid\":\"80010119-6d7f-0000-0305-5e0000000256\",\"logic\":{\"data\":[{\"cid\":13112,\"weight\":1},{\"cid\":13114,\"weight\":1},{\"cid\":13115,\"weight\":1},{\"cid\":13113,\"weight\":1}],\"targetScore\":1,\"type\":\"weightedComponentList\",\"version\":1},\"throttle\":3600,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[\"\",\"AP:C2Comms\"],\"interval\":3600,\"delay\":0,\"sequenced\":false,\"active\":true,\"modified\":\"2022-06-22 15:56:27\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"AdeviceisobservedmakingDNSrequestsorconnectionstowatcheddomainsorIPaddresses.ThewatchlistcanbeeditedfromthemainGUImenu,Intelsub-menu,undertheiconWatchedDomains.\\n\\nAction:ReviewthedomainandIPbeingconnectedto.\",\"behaviour\":\"decreasing\",\"defeats\":[],\"created\":{\"by\":\"System\"},\"edited\":{\"by\":\"System\"},\"message\":\"Adjustingmodellogicforproxiedconnections\",\"version\":31,\"priority\":5,\"category\":\"Critical\",\"compliance\":false}},\"triggeredComponents\":[{\"time\":1687774141000,\"cbid\":25885,\"cid\":13112,\"chid\":20980,\"size\":1,\"threshold\":0,\"interval\":3600,\"logic\":{\"data\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":\"F\"}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":\"F\"}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":\"G\"}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"E\",\"operator\":\"AND\",\"right\":\"G\"}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":\"I\"}}}},\"operator\":\"OR\",\"right\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":{\"left\":\"D\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":\"I\"}}}}}}}}},\"version\":\"v0.1\"},\"ip\":\"192.168.1.2/32\",\"port\":53,\"metric\":{\"mlid\":223,\"name\":\"dtwatcheddomain\",\"label\":\"WatchedDomain\"},\"triggeredFilters\":[{\"cfid\":156173,\"id\":\"A\",\"filterType\":\"Watchedendpointsource\",\"arguments\":{\"value\":\".+\"},\"comparatorType\":\"doesnotmatchregularexpression\",\"trigger\":{\"value\":\"\"}},{\"cfid\":156175,\"id\":\"C\",\"filterType\":\"Direction\",\"arguments\":{\"value\":\"out\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"out\"}},{\"cfid\":156177,\"id\":\"E\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{\"value\":\"12\"},\"comparatorType\":\"isnot\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":156179,\"id\":\"G\",\"filterType\":\"Destinationport\",\"arguments\":{\"value\":53},\"comparatorType\":\"=\",\"trigger\":{\"value\":\"53\"}},{\"cfid\":156180,\"id\":\"d1\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"6\"}},{\"cfid\":156181,\"id\":\"d10\",\"filterType\":\"Watchedendpointdescription\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":156182,\"id\":\"d2\",\"filterType\":\"Connectionhostname\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":156183,\"id\":\"d3\",\"filterType\":\"DestinationIP\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"192.168.1.2\"}},{\"cfid\":156184,\"id\":\"d4\",\"filterType\":\"ASN\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":156185,\"id\":\"d5\",\"filterType\":\"Country\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":156186,\"id\":\"d6\",\"filterType\":\"Message\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"amazonlinux-2-repos-eu-west-2.s3.eu-west-2.amazonaws.com\"}},{\"cfid\":156187,\"id\":\"d7\",\"filterType\":\"Watchedendpoint\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"true\"}},{\"cfid\":156188,\"id\":\"d8\",\"filterType\":\"Watchedendpointsource\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":156189,\"id\":\"d9\",\"filterType\":\"Watchedendpointstrength\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"100\"}},{\"cfid\":156190,\"id\":\"H\",\"filterType\":\"Internaldestination\",\"arguments\":{},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"true\"}},{\"cfid\":156191,\"id\":\"I\",\"filterType\":\"Internaldestinationdevicetype\",\"arguments\":{\"value\":\"11\"},\"comparatorType\":\"isnot\",\"trigger\":{\"value\":\"12\"}}]}],\"score\":0.541,\"device\":{\"did\":6,\"ip\":\"192.168.16.#54818\",\"ips\":[{\"ip\":\"192.168.16.#54818\",\"timems\":1688385600000,\"time\":\"2023-07-0312:00:00\",\"sid\":4}],\"sid\":4,\"firstSeen\":1639068361000,\"lastSeen\":1688385853000,\"typename\":\"desktop\",\"typelabel\":\"Desktop\"}}",
+        "event": {
+            "category": "network",
+            "end": "2022-06-22T15:56:27Z",
+            "kind": "alert",
+            "type": [
+                "info"
+            ]
+        },
+        "@timestamp": "2023-06-26T10:09:02Z",
+        "host": {
+            "id": "6",
+            "ip": []
+        },
+        "observer": {
+            "name": "Darktrace",
+            "product": "Threat visualizer"
+        },
+        "darktrace": {
+            "threat_visualizer": {
+                "creationTime": 1687774148000,
+                "commentCount": 0,
+                "pbid": 25808,
+                "time": 1687774142000,
+                "model": {
+                    "then": {
+                        "name": "Compromise::WatchedDomain",
+                        "pid": 608,
+                        "phid": 6768,
+                        "uuid": "80010119-6d7f-0000-0305-5e0000000256",
+                        "tags": [
+                            "",
+                            "AP:C2Comms"
+                        ],
+                        "description": "AdeviceisobservedmakingDNSrequestsorconnectionstowatcheddomainsorIPaddresses.ThewatchlistcanbeeditedfromthemainGUImenu,Intelsub-menu,undertheiconWatchedDomains.\n\nAction:ReviewthedomainandIPbeingconnectedto.",
+                        "category": "Critical",
+                        "priority": 5,
+                        "behaviour": "decreasing",
+                        "defeats": [],
+                        "version": 31
+                    },
+                    "now": {
+                        "name": "Compromise::WatchedDomain",
+                        "pid": 608,
+                        "phid": 6768,
+                        "uuid": "80010119-6d7f-0000-0305-5e0000000256",
+                        "tags": [
+                            "",
+                            "AP:C2Comms"
+                        ],
+                        "description": "AdeviceisobservedmakingDNSrequestsorconnectionstowatcheddomainsorIPaddresses.ThewatchlistcanbeeditedfromthemainGUImenu,Intelsub-menu,undertheiconWatchedDomains.\n\nAction:ReviewthedomainandIPbeingconnectedto.",
+                        "behaviour": "decreasing",
+                        "defeats": [],
+                        "message": "Adjustingmodellogicforproxiedconnections",
+                        "priority": 5,
+                        "category": "Critical",
+                        "version": 31
+                    }
+                },
+                "score": 0.541,
+                "device": {
+                    "ip": "192.168.16.#54818",
+                    "ips": [
+                        {
+                            "ip": "192.168.16.#54818",
+                            "timems": 1688385600000,
+                            "time": "2023-07-0312:00:00",
+                            "sid": 4
+                        }
+                    ],
+                    "sid": 4,
+                    "firstSeen": 1639068361000,
+                    "lastSeen": 1688385853000,
+                    "typename": "desktop",
+                    "typelabel": "Desktop"
+                }
+            }
+        },
+        "related": {
+            "ip": []
+        }
+    }
+    	
+	```
+
+
+=== "test_device_threat_indicator.json"
+
+    ```json
+	
+    {
+        "message": "{\"commentCount\":0,\"pbid\":25860,\"time\":1687793533000,\"creationTime\":1687793540000,\"model\":{\"then\":{\"name\":\"Device::ThreatIndicator\",\"pid\":540,\"phid\":6656,\"uuid\":\"84c92ea6-36b9-402f-9df1-3c5bfaee9176\",\"logic\":{\"data\":[{\"cid\":12878,\"weight\":1},{\"cid\":12876,\"weight\":1},{\"cid\":12877,\"weight\":1}],\"targetScore\":1,\"type\":\"weightedComponentList\",\"version\":1},\"throttle\":3600,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false,\"tagTTL\":604800},\"tags\":[\"\",\"RequiresConfiguration\"],\"interval\":1,\"delay\":0,\"sequenced\":false,\"active\":true,\"modified\":\"2022-06-15 12:01:36\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"AdevicehasvisitedanexternallocationthathasbeenidentifiedbyanIndicatoraddedtothewatchlistsorviaTAXII.\\n\\nAction:InvestigatedevicesnetworkbehaviourspayingparticularattentiontothedomainsorIPsbeinghighlighted.Verifytheindicatorisatruemaliciousindicator.,behaviour:decreasing,created:{by:System},edited:{by:System},version:39,priority:5,category:Critical,compliance:false},now:{name:Device::ThreatIndicator,pid:540,phid:6656,uuid:84c92ea6-36b9-402f-9df1-3c5bfaee9176,logic:{data:[{cid:12878,weight:1},{cid:12876,weight:1},{cid:12877,weight:1}],targetScore:1,type:weightedComponentList,version:1},throttle:3600,sharedEndpoints:false,actions:{alert:true,antigena:{},breach:true,model:true,setPriority:false,setTag:false,setType:false,tagTTL:604800},tags:[,RequiresConfiguration],interval:1,delay:0,sequenced:false,active:true,modified:2022-06-15 12:01:36,activeTimes:{devices:{},tags:{},type:exclusions,version:2},autoUpdatable:true,autoUpdate:true,autoSuppress:true,description:AdevicehasvisitedanexternallocationthathasbeenidentifiedbyanIndicatoraddedtothewatchlistsorviaTAXII.nnAction:InvestigatedevicesnetworkbehaviourspayingparticularattentiontothedomainsorIPsbeinghighlighted.Verifytheindicatorisatruemaliciousindicator.\",\"behaviour\":\"decreasing\",\"created\":{\"by\":\"System\"},\"edited\":{\"by\":\"System\"},\"message\":\"UpdatedWatchedendpointsourceregextoexcludeAttackSurfaceManagement\",\"version\":39,\"priority\":5,\"category\":\"Critical\",\"compliance\":false}},\"triggeredComponents\":[{\"time\":1687793532000,\"cbid\":25937,\"cid\":12876,\"chid\":20545,\"size\":1,\"threshold\":0,\"interval\":3600,\"logic\":{\"data\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"F\",\"operator\":\"AND\",\"right\":{\"left\":\"G\",\"operator\":\"AND\",\"right\":{\"left\":\"H\",\"operator\":\"AND\",\"right\":{\"left\":\"I\",\"operator\":\"AND\",\"right\":{\"left\":\"J\",\"operator\":\"AND\",\"right\":\"K\"}}}}}},\"version\":\"v0.1\"},\"ip\":\"192.168.1.2/32\",\"port\":53,\"metric\":{\"mlid\":223,\"name\":\"dtwatcheddomain\",\"label\":\"WatchedDomain\"},\"triggeredFilters\":[{\"cfid\":153437,\"id\":\"A\",\"filterType\":\"Watchedendpointsource\",\"arguments\":{\"value\":\"^(\\\\_?Darktrace.*|AttackSurfaceManagement)\"},\"comparatorType\":\"doesnotmatchregularexpression\",\"trigger\":{\"value\":\"ThreatIntel\"}},{\"cfid\":153437,\"id\":\"A\",\"filterType\":\"Watchedendpointsource\",\"arguments\":{\"value\":\"^(\\\\_?Darktrace.*|AttackSurfaceManagement)\"},\"comparatorType\":\"doesnotmatchregularexpression\",\"trigger\":{\"value\":\"\"}},{\"cfid\":153438,\"id\":\"F\",\"filterType\":\"Watchedendpointsource\",\"arguments\":{\"value\":\".+\"},\"comparatorType\":\"matchesregularexpression\",\"trigger\":{\"value\":\"ThreatIntel\"}},{\"cfid\":153439,\"id\":\"G\",\"filterType\":\"Watchedendpointsource\",\"arguments\":{\"value\":\"Default\"},\"comparatorType\":\"doesnotmatch\",\"trigger\":{\"value\":\"ThreatIntel\"}},{\"cfid\":153439,\"id\":\"G\",\"filterType\":\"Watchedendpointsource\",\"arguments\":{\"value\":\"Default\"},\"comparatorType\":\"doesnotmatch\",\"trigger\":{\"value\":\"\"}},{\"cfid\":153440,\"id\":\"H\",\"filterType\":\"Taggedinternalsource\",\"arguments\":{\"value\":4},\"comparatorType\":\"doesnothavetag\",\"trigger\":{\"value\":\"4\",\"tag\":{\"tid\":4,\"expiry\":0,\"thid\":4,\"name\":\"SecurityDevice\",\"restricted\":false,\"data\":{\"auto\":false,\"color\":55,\"description\":\"\",\"visibility\":\"Public\"},\"isReferenced\":true}}},{\"cfid\":153441,\"id\":\"I\",\"filterType\":\"Internalsourcedevicetype\",\"arguments\":{\"value\":\"12\"},\"comparatorType\":\"isnot\",\"trigger\":{\"value\":\"7\"}},{\"cfid\":153442,\"id\":\"J\",\"filterType\":\"Taggedinternalsource\",\"arguments\":{\"value\":18},\"comparatorType\":\"doesnothavetag\",\"trigger\":{\"value\":\"18\",\"tag\":{\"tid\":18,\"expiry\":0,\"thid\":18,\"name\":\"DNSServer\",\"restricted\":false,\"data\":{\"auto\":false,\"color\":112,\"description\":\"DevicesreceivingandmakingDNSqueries\",\"visibility\":\"Public\"},\"isReferenced\":true}}},{\"cfid\":153443,\"id\":\"K\",\"filterType\":\"Direction\",\"arguments\":{\"value\":\"out\"},\"comparatorType\":\"is\",\"trigger\":{\"value\":\"out\"}},{\"cfid\":153444,\"id\":\"d1\",\"filterType\":\"Ageofdestination\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"38123579\"}},{\"cfid\":153445,\"id\":\"d2\",\"filterType\":\"Country\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":153446,\"id\":\"d3\",\"filterType\":\"DestinationIP\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"192.168.1.2\"}},{\"cfid\":153447,\"id\":\"d4\",\"filterType\":\"ASN\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":153448,\"id\":\"d5\",\"filterType\":\"Destinationport\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"53\"}},{\"cfid\":153449,\"id\":\"d6\",\"filterType\":\"Rareexternalendpoint\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"0\"}},{\"cfid\":153450,\"id\":\"d7\",\"filterType\":\"Watchedendpointsource\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"ThreatIntel\"}},{\"cfid\":153450,\"id\":\"d7\",\"filterType\":\"Watchedendpointsource\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"\"}},{\"cfid\":153451,\"id\":\"d8\",\"filterType\":\"Message\",\"arguments\":{},\"comparatorType\":\"display\",\"trigger\":{\"value\":\"clients2.google.com\"}}]}],\"score\":0.612,\"device\":{\"did\":39,\"vendor\":\"\",\"ip\":\"192.168.1.3\",\"ips\":[{\"ip\":\"192.168.1.3\",\"timems\":1688389200000,\"time\":\"2023-07-0313:00:00\",\"sid\":3}],\"sid\":3,\"firstSeen\":1666276905000,\"lastSeen\":1688391268000,\"os\":\"Windows(10.0)\",\"typename\":\"server\",\"typelabel\":\"Server\"}}",
+        "event": {
+            "category": "network",
+            "end": "2022-06-15T12:01:36Z",
+            "kind": "alert",
+            "type": [
+                "info"
+            ]
+        },
+        "@timestamp": "2023-06-26T15:32:13Z",
+        "host": {
+            "id": "39",
+            "ip": [
+                "192.168.1.3"
+            ]
+        },
+        "observer": {
+            "name": "Darktrace",
+            "product": "Threat visualizer"
+        },
+        "darktrace": {
+            "threat_visualizer": {
+                "creationTime": 1687793540000,
+                "commentCount": 0,
+                "pbid": 25860,
+                "time": 1687793533000,
+                "model": {
+                    "then": {
+                        "name": "Device::ThreatIndicator",
+                        "pid": 540,
+                        "phid": 6656,
+                        "uuid": "84c92ea6-36b9-402f-9df1-3c5bfaee9176",
+                        "tags": [
+                            "",
+                            "RequiresConfiguration"
+                        ],
+                        "description": "AdevicehasvisitedanexternallocationthathasbeenidentifiedbyanIndicatoraddedtothewatchlistsorviaTAXII.\n\nAction:InvestigatedevicesnetworkbehaviourspayingparticularattentiontothedomainsorIPsbeinghighlighted.Verifytheindicatorisatruemaliciousindicator.,behaviour:decreasing,created:{by:System},edited:{by:System},version:39,priority:5,category:Critical,compliance:false},now:{name:Device::ThreatIndicator,pid:540,phid:6656,uuid:84c92ea6-36b9-402f-9df1-3c5bfaee9176,logic:{data:[{cid:12878,weight:1},{cid:12876,weight:1},{cid:12877,weight:1}],targetScore:1,type:weightedComponentList,version:1},throttle:3600,sharedEndpoints:false,actions:{alert:true,antigena:{},breach:true,model:true,setPriority:false,setTag:false,setType:false,tagTTL:604800},tags:[,RequiresConfiguration],interval:1,delay:0,sequenced:false,active:true,modified:2022-06-15 12:01:36,activeTimes:{devices:{},tags:{},type:exclusions,version:2},autoUpdatable:true,autoUpdate:true,autoSuppress:true,description:AdevicehasvisitedanexternallocationthathasbeenidentifiedbyanIndicatoraddedtothewatchlistsorviaTAXII.nnAction:InvestigatedevicesnetworkbehaviourspayingparticularattentiontothedomainsorIPsbeinghighlighted.Verifytheindicatorisatruemaliciousindicator.",
+                        "category": "Critical",
+                        "priority": 5,
+                        "behaviour": "decreasing",
+                        "version": 39
+                    }
+                },
+                "score": 0.612,
+                "device": {
+                    "ip": "192.168.1.3",
+                    "ips": [
+                        {
+                            "ip": "192.168.1.3",
+                            "timems": 1688389200000,
+                            "time": "2023-07-0313:00:00",
+                            "sid": 3
+                        }
+                    ],
+                    "sid": 3,
+                    "firstSeen": 1666276905000,
+                    "lastSeen": 1688391268000,
+                    "typename": "server",
+                    "typelabel": "Server"
+                }
+            }
+        },
+        "related": {
+            "ip": [
+                "192.168.1.3"
+            ]
+        }
+    }
+    	
+	```
+
+
+=== "test_pentest.json"
+
+    ```json
+	
+    {
+        "message": "{\"commentCount\":0,\"pbid\":25908,\"time\":1687811707000,\"creationTime\":1687811713000,\"model\":{\"then\":{\"name\":\"PenTest\",\"pid\":2721,\"phid\":9287,\"uuid\":\"8b3d5e73-0cf0-4c32-8451-a6919b9978f8\",\"logic\":{\"data\":[18021],\"type\":\"componentList\",\"version\":1},\"throttle\":1000,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[],\"interval\":3600,\"delay\":0,\"sequenced\":true,\"active\":true,\"modified\":\"2023-04-17 11:34:25\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":true,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"\",\"behaviour\":\"flat\",\"defeats\":[],\"created\":{\"by\":\"sam.gorse\",\"userID\":22},\"edited\":{\"by\":\"sam.gorse\",\"userID\":22},\"version\":7,\"priority\":5,\"category\":\"Critical\",\"compliance\":false},\"now\":{\"name\":\"PenTest\",\"pid\":2721,\"phid\":9287,\"uuid\":\"8b3d5e73-0cf0-4c32-8451-a6919b9978f8\",\"logic\":{\"data\":[18021],\"type\":\"componentList\",\"version\":1},\"throttle\":1000,\"sharedEndpoints\":false,\"actions\":{\"alert\":true,\"antigena\":{},\"breach\":true,\"model\":true,\"setPriority\":false,\"setTag\":false,\"setType\":false},\"tags\":[],\"interval\":3600,\"delay\":0,\"sequenced\":true,\"active\":true,\"modified\":\"2023-04-17 11:34:25\",\"activeTimes\":{\"devices\":{},\"tags\":{},\"type\":\"exclusions\",\"version\":2},\"autoUpdatable\":false,\"autoUpdate\":true,\"autoSuppress\":true,\"description\":\"\",\"behaviour\":\"flat\",\"defeats\":[],\"created\":{\"by\":\"sam.gorse\",\"userID\":22},\"edited\":{\"by\":\"sam.gorse\",\"userID\":22},\"version\":7,\"priority\":5,\"category\":\"Critical\",\"compliance\":false}},\"triggeredComponents\":[{\"time\":1687811706000,\"cbid\":25985,\"cid\":18021,\"chid\":29073,\"size\":1,\"threshold\":0,\"interval\":3600,\"logic\":{\"data\":{\"left\":\"A\",\"operator\":\"OR\",\"right\":{\"left\":\"B\",\"operator\":\"OR\",\"right\":{\"left\":\"C\",\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":\"D\"}}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":\"B\"},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":\"C\"},\"operator\":\"OR\",\"right\":{\"left\":\"D\",\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":\"C\"}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"B\",\"operator\":\"AND\",\"right\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":\"D\"}},\"operator\":\"OR\",\"right\":{\"left\":{\"left\":\"C\",\"operator\":\"AND\",\"right\":\"D\"},\"operator\":\"OR\",\"right\":{\"left\":\"A\",\"operator\":\"AND\",\"right\":\"D\"}}}}}}}}}}},\"version\":\"v0.1\"},\"ip\":\"192.168.16.100/32\",\"port\":80,\"metric\":{\"mlid\":16,\"name\":\"connections\",\"label\":\"Connections\"},\"triggeredFilters\":[{\"cfid\":217209,\"id\":\"C\",\"filterType\":\"Destinationport\",\"arguments\":{\"value\":80},\"comparatorType\":\"=\",\"trigger\":{\"value\":\"80\"}}]}],\"score\":1.0,\"device\":{\"did\":31,\"vendor\":\"\",\"ip\":\"192.168.1.2\",\"ips\":[{\"ip\":\"192.168.1.2\",\"timems\":1688389200000,\"time\":\"2023-07-0313:00:00\",\"sid\":3}],\"sid\":3,\"firstSeen\":1649669953000,\"lastSeen\":1688391406000,\"typename\":\"dnsserver\",\"typelabel\":\"DNSServer\"}}",
+        "event": {
+            "category": "network",
+            "end": "2023-04-17T11:34:25Z",
+            "kind": "alert",
+            "type": [
+                "info"
+            ]
+        },
+        "@timestamp": "2023-06-26T20:35:07Z",
+        "host": {
+            "id": "31",
+            "ip": [
+                "192.168.1.2"
+            ]
+        },
+        "observer": {
+            "name": "Darktrace",
+            "product": "Threat visualizer"
+        },
+        "darktrace": {
+            "threat_visualizer": {
+                "creationTime": 1687811713000,
+                "commentCount": 0,
+                "pbid": 25908,
+                "time": 1687811707000,
+                "model": {
+                    "then": {
+                        "name": "PenTest",
+                        "pid": 2721,
+                        "phid": 9287,
+                        "uuid": "8b3d5e73-0cf0-4c32-8451-a6919b9978f8",
+                        "tags": [],
+                        "category": "Critical",
+                        "priority": 5,
+                        "behaviour": "flat",
+                        "defeats": [],
+                        "version": 7
+                    },
+                    "now": {
+                        "name": "PenTest",
+                        "pid": 2721,
+                        "phid": 9287,
+                        "uuid": "8b3d5e73-0cf0-4c32-8451-a6919b9978f8",
+                        "tags": [],
+                        "behaviour": "flat",
+                        "defeats": [],
+                        "edited": {
+                            "userID": 22
+                        },
+                        "priority": 5,
+                        "category": "Critical",
+                        "version": 7
+                    }
+                },
+                "score": 1.0,
+                "device": {
+                    "ip": "192.168.1.2",
+                    "ips": [
+                        {
+                            "ip": "192.168.1.2",
+                            "timems": 1688389200000,
+                            "time": "2023-07-0313:00:00",
+                            "sid": 3
+                        }
+                    ],
+                    "sid": 3,
+                    "firstSeen": 1649669953000,
+                    "lastSeen": 1688391406000,
+                    "typename": "dnsserver",
+                    "typelabel": "DNSServer"
+                }
+            }
+        },
+        "related": {
+            "ip": [
+                "192.168.1.2"
+            ]
+        }
+    }
+    	
+	```
+
+
+
+
+
+## Extracted Fields
+
+The following table lists the fields that are extracted, normalized under the ECS format, analyzed and indexed by the parser. It should be noted that infered fields are not listed.
+
+| Name | Type | Description                |
+| ---- | ---- | ---------------------------|
+|`@timestamp` | `date` | Date/time when the event originated. |
+|`darktrace.threat_visualizer.commentCount` | `number` | The number of comments made against this breach. |
+|`darktrace.threat_visualizer.creationTime` | `number` | The timestamp that the record of the breach was created. This is distinct from the time field. |
+|`darktrace.threat_visualizer.device.firstSeen` | `number` | The first time the device was seen on the network. |
+|`darktrace.threat_visualizer.device.ip` | `string` | The current IP associated with the device. |
+|`darktrace.threat_visualizer.device.ips` | `array` | IPs associated with the device historically. |
+|`darktrace.threat_visualizer.device.ips.ip` | `string` | A historic IP associated with the device. |
+|`darktrace.threat_visualizer.device.ips.sid` | `number` | The subnet id for the subnet the IP belongs to. |
+|`darktrace.threat_visualizer.device.ips.time` | `string` | The time the IP was last seen associated with that device in readable format. |
+|`darktrace.threat_visualizer.device.ips.timems` | `number` | The time the IP was last seen associated with that device in epoch time. |
+|`darktrace.threat_visualizer.device.lastSeen` | `number` | The last time the device was seen on the network. |
+|`darktrace.threat_visualizer.device.sid` | `number` | The subnet id for the subnet the device is currently located in. |
+|`darktrace.threat_visualizer.device.typelabel` | `keyword` | The device type in readable format. |
+|`darktrace.threat_visualizer.device.typename` | `keyword` | The device type in system format. |
+|`darktrace.threat_visualizer.model.now.behaviour` | `string` | The score modulation function as set in the model editor. |
+|`darktrace.threat_visualizer.model.now.category` | `string` | The behavior category associated with the model at the time of request. |
+|`darktrace.threat_visualizer.model.now.defeats` | `array` | An array of model defeats - AND conditions - which if met, prevent the model from breaching. |
+|`darktrace.threat_visualizer.model.now.defeats.arguments.value` | `string` |  |
+|`darktrace.threat_visualizer.model.now.defeats.comparator` | `string` | The comparator that the value is compared against the create the defeat. |
+|`darktrace.threat_visualizer.model.now.defeats.defeatID` | `number` | A unique ID for the defeat. |
+|`darktrace.threat_visualizer.model.now.defeats.filtertype` | `string` | The filter the defeat is made from. |
+|`darktrace.threat_visualizer.model.now.description` | `string` | The optional description of the model. |
+|`darktrace.threat_visualizer.model.now.edited.userID` | `number` | Username that last edited the model. |
+|`darktrace.threat_visualizer.model.now.message` | `string` | The commit message for the change. |
+|`darktrace.threat_visualizer.model.now.mitre.tactics` | `array` | An array of MITRE ATT&CK framework tactics the model has been mapped to. |
+|`darktrace.threat_visualizer.model.now.mitre.techniques` | `array` | An array of MITRE ATT&CK framework techniques the model has been mapped to. |
+|`darktrace.threat_visualizer.model.now.name` | `string` | Name of the model that was breached. |
+|`darktrace.threat_visualizer.model.now.phid` | `number` | The model policy history id. Increments when the model is modified. |
+|`darktrace.threat_visualizer.model.now.pid` | `number` | The policy id of the model that was breached. |
+|`darktrace.threat_visualizer.model.now.priority` | `number` | The numeric behavior category associated with the model at the time of request: 0-3 equates to informational, 4 equates to suspicious and 5 equates to critical. |
+|`darktrace.threat_visualizer.model.now.tags` | `array` | AP: Bruteforce |
+|`darktrace.threat_visualizer.model.now.uuid` | `string` | A unique ID that is generated on creation of the model. |
+|`darktrace.threat_visualizer.model.now.version` | `number` | The version of the model. Increments on each edit. |
+|`darktrace.threat_visualizer.model.then.behaviour` | `string` | The score modulation function as set in the model editor. |
+|`darktrace.threat_visualizer.model.then.category` | `string` | The behavior category associated with the model at the time of the breach. |
+|`darktrace.threat_visualizer.model.then.defeats` | `array` | An array of model defeats - AND conditions - which if met, prevent the model from breaching. |
+|`darktrace.threat_visualizer.model.then.defeats.arguments.value` | `string` |  |
+|`darktrace.threat_visualizer.model.then.defeats.comparator` | `string` | The comparator that the value is compared against the create the defeat. |
+|`darktrace.threat_visualizer.model.then.defeats.defeatID` | `number` | A unique ID for the defeat. |
+|`darktrace.threat_visualizer.model.then.defeats.filtertype` | `string` | The filter the defeat is made from. |
+|`darktrace.threat_visualizer.model.then.description` | `string` | The optional description of the model. |
+|`darktrace.threat_visualizer.model.then.mitre.tactics` | `array` | An array of MITRE ATT&CK framework tactics the model has been mapped to. |
+|`darktrace.threat_visualizer.model.then.mitre.techniques` | `array` | An array of MITRE ATT&CK framework techniques the model has been mapped to. |
+|`darktrace.threat_visualizer.model.then.name` | `string` | Name of the model that was breached. |
+|`darktrace.threat_visualizer.model.then.phid` | `number` | The model policy history id. Increments when the model is modified. |
+|`darktrace.threat_visualizer.model.then.pid` | `number` | The policy id of the model that was breached. |
+|`darktrace.threat_visualizer.model.then.priority` | `number` | The numeric behavior category associated with the model at the time of the breach: 0-3 equates to informational, 4 equates to suspicious and 5 equates to critical. |
+|`darktrace.threat_visualizer.model.then.tags` | `array` | A list of tags that have been applied to this model in the Threat Visualizer model editor. |
+|`darktrace.threat_visualizer.model.then.uuid` | `string` | A unique ID that is generated on creation of the model. |
+|`darktrace.threat_visualizer.model.then.version` | `number` | The version of the model. Increments on each edit. |
+|`darktrace.threat_visualizer.pbid` | `number` | The policy breach ID of the model breach. |
+|`darktrace.threat_visualizer.score` | `number` | The model breach score, represented by a value between 0 and 1. |
+|`darktrace.threat_visualizer.time` | `number` | The timestamp when the record was created in epoch time. |
+|`event.category` | `keyword` | Event category. The second categorization field in the hierarchy. |
+|`event.end` | `date` | event.end contains the date when the event ended or when the activity was last observed. |
+|`event.kind` | `keyword` | The kind of the event. The highest categorization field in the hierarchy. |
+|`event.type` | `keyword` | Event type. The third categorization field in the hierarchy. |
+|`host.hostname` | `keyword` | Hostname of the host. |
+|`host.id` | `keyword` | Unique host id. |
+|`host.ip` | `ip` | Host ip addresses. |
+|`observer.name` | `keyword` | Custom name of the observer. |
+|`observer.product` | `keyword` | The product name of the observer. |
+

--- a/_shared_content/operations_center/integrations/generated/99da26fc-bf7b-4e5b-a76c-408472fcfebb.md
+++ b/_shared_content/operations_center/integrations/generated/99da26fc-bf7b-4e5b-a76c-408472fcfebb.md
@@ -1,0 +1,289 @@
+
+## Event Categories
+
+
+The following table lists the data source offered by this integration.
+
+| Data Source | Description                          |
+| ----------- | ------------------------------------ |
+| `File monitoring` | Monitor files and devices activities |
+| `Process monitoring` | Monitor process activities |
+| `Process use of network` | Monitor network activities |
+
+
+
+
+
+In details, the following table denotes the type of events produced by this integration.
+
+| Name | Values |
+| ---- | ------ |
+| Kind | `event` |
+| Category | `` |
+| Type | `` |
+
+
+
+
+## Event Samples
+
+Find below few samples of events and how they are normalized by SEKOIA.IO.
+
+
+=== "ioc_view_query.json"
+
+    ```json
+	
+    {
+        "message": "{\"upload_size\":1077,\"record_identifier\":\"d327f865227909ad464d67f8\",\"ioc_severity\":4,\"path\":\"HKEY_LOCAL Options\",\"ioc_detection_cvss\":\"4\",\"analysis\":\"{\\\"dep_opt_out\\\":0,\\\"dep_alwayson\\\":0,\\\"dep_opt_in\\\":1}\",\"ioc_detection_sigma\":\"{\\\"id\\\":\\\"COMPLIANCE-DEP-PERMISSIVE\\\",\\\"logsource\\\":{\\\"dedup_fields\\\":[\\\"machine_data.name\\\"],\\\"product\\\":\\\"windows\\\",\\\"platform\\\":\\\"windows\\\",\\\"category\\\":\\\"vulnerability_dep\\\",\\\"references\\\":[\\\"http://www.test.com/\\\"]}}\",\"folded\":0,\"meta_mac_address\":\"01:02:03:04:05:06\",\"endpoint_id\":\"0a7e076f-k4p1-428a-8304-azedazedazef\",\"meta_public_ip_country_code\":\"FR\",\"meta_public_ip_postal\":\"35750\",\"schema_version\":\"20\",\"ioc_detection_mitre_attack\":\"[]\",\"ioc_detection_experiment_level\":0,\"ioc_detection_access\":\"{\\\"authentication\\\":\\\"None\\\",\\\"complexity\\\":\\\"Low\\\",\\\"vector\\\":\\\"Local\\\"}\",\"ioc_created_at\":\"2022-11-30T09:23:22.226Z\",\"ingestion_timestamp\":\"2022-11-30T09:22:29.980Z\",\"ioc_detection_attack\":\"Exposure\",\"numerics\":false,\"meta_public_ip\":\"1.2.3.4\",\"counter\":2,\"detection_id_dedup\":\"azeifazeiofuhapizefhapzieofhazeufh\",\"meta_hostname\":\"AC061-E44iauzebf\",\"ioc_detection_references\":\"[\\\"http://www.test.com\\\"]\",\"ioc_worker_name\":\"Direct Mapping Worker\",\"ioc_detection_type\":\"Vulnerability\",\"ioc_detection_category\":\"Vulnerability\",\"ioc_unix_time\":\"2022-11-30T09:22:11.000Z\",\"epoch\":1669619877,\"meta_ip_mask\":\"1.2.3.4\",\"meta_public_ip_city\":\"Paris\",\"ioc_worker_id\":\"direct_mapping_worker\",\"unix_time\":\"2022-11-30T09:22:11.000Z\",\"ioc_log_type\":\"summary\",\"query_source\":\"xdr_only\",\"host_identifier\":\"4C4C4544-0035-4E10-8044-B3C04F5A3333\",\"partition_bucket\":\"87\",\"meta_public_ip_country\":\"France\",\"meta_public_ip_state\":\"Paris\",\"meta_boot_time\":1669798899,\"meta_os_name\":\"Microsoft Windows 10 Professionnel\",\"osquery_action\":\"added\",\"meta_query_pack_version\":\"1.14.90\",\"calendar_time\":\"2022-11-30T09:22:11.000Z\",\"meta_eid\":\"0a7e076f-0316-428a-8304-fea736738c7a\",\"meta_public_ip_longitude\":2.4075,\"ioc_detection_id\":\"COMPLIANCE-DEP-PERMISSIVE\",\"meta_os_platform\":\"windows\",\"meta_username\":\"AC712341234\",\"detection_identifier\":\"d327f865227909ad464d67f8fc9d8e38c4285299f4\",\"query_name\":\"vulnerability_dep\",\"key\":\"HKEY_LOCAL_MACHINE Control\",\"meta_os_version\":\"10.0.19044\",\"meta_public_ip_latitude\":39,\"mtime\":1669757890,\"ioc_detection_licenses\":\"[\\\"MTR\\\"]\",\"name\":\"SystemStartOptions\",\"meta_aggressive_activity\":\"False\",\"meta_ip_address\":\"1.2.3.4\",\"type\":\"REG_SZ\",\"ingest_date\":\"2022-11-30\",\"ioc_detection_impact\":\"{\\\"availability\\\":\\\"Partial\\\",\\\"confidentiality\\\":\\\"Partial\\\",\\\"integrity\\\":\\\"Partial\\\"}\",\"meta_endpoint_type\":\"computer\",\"meta_domain_controller\":\"False\",\"customer_id\":\"f7193486-a186-4197-ab40-0ddc013a0a65\",\"data\":\" NOEXECUTE=OPTIN  FVEBOOT=1234567  NOVGA\",\"ioc_detection_description\":\"DEP is not Admin Opt-out or Always-on.\",\"message_identifier\":\"ofiazefoazebfaozuefazeo\",\"ioc_attack_type\":\"Exposure\",\"ioc_detection_weight\":4}",
+        "event": {
+            "kind": "event",
+            "severity": 4,
+            "code": "COMPLIANCE-DEP-PERMISSIVE"
+        },
+        "@timestamp": "2022-11-30T09:22:11Z",
+        "user": {
+            "name": "AC712341234"
+        },
+        "registry": {
+            "path": "HKEY_LOCAL Options",
+            "key": "HKEY_LOCAL_MACHINE Control",
+            "data": {
+                "type": "REG_SZ",
+                "strings": [
+                    " NOEXECUTE=OPTIN  FVEBOOT=1234567  NOVGA"
+                ]
+            }
+        },
+        "source": {
+            "ip": "1.2.3.4",
+            "mac": "01:02:03:04:05:06",
+            "geo": {
+                "country_iso_code": "FR",
+                "postal_code": "35750",
+                "city_name": "Paris",
+                "country_name": "France"
+            },
+            "address": "1.2.3.4"
+        },
+        "host": {
+            "name": "AC061-E44iauzebf",
+            "id": "4C4C4544-0035-4E10-8044-B3C04F5A3333",
+            "os": {
+                "name": "Microsoft Windows 10 Professionnel",
+                "version": "10.0.19044"
+            }
+        },
+        "vulnerability": {
+            "reference": "http://www.test.com",
+            "description": "DEP is not Admin Opt-out or Always-on."
+        },
+        "sophos": {
+            "threat_center": {
+                "cvss": "4",
+                "id": "0a7e076f-k4p1-428a-8304-azedazedazef",
+                "detection_attack": "Exposure",
+                "query": {
+                    "source": "xdr_only",
+                    "action": "added",
+                    "pack_version": "1.14.90",
+                    "name": "vulnerability_dep"
+                },
+                "endpoint": {
+                    "type": "computer"
+                }
+            }
+        },
+        "related": {
+            "ip": [
+                "1.2.3.4"
+            ],
+            "user": [
+                "AC712341234"
+            ]
+        }
+    }
+    	
+	```
+
+
+=== "ioc_view_query1.json"
+
+    ```json
+	
+    {
+        "message": "{\"upload_size\":1291,\"record_identifier\":\"09dd5e717aa664189dqehbfazuebfazuebfiaze\",\"ioc_severity\":4,\"path\":\"LOCAL_MACHINE/test.exe\",\"ioc_detection_cvss\":\"4\",\"analysis\":\"{\\\"os_compatibility_target\\\":\\\"test\\\"}\",\"ioc_detection_sigma\":\"{\\\"id\\\":\\\"COMPLIANCE-APP-COMPAT\\\",\\\"logsource\\\":{\\\"dedup_fields\\\":[\\\"machine_data.name\\\"],\\\"product\\\":\\\"windows\\\",\\\"platform\\\":\\\"windows\\\",\\\"category\\\":\\\"vulnerability_app_compatibility\\\",\\\"references\\\":[\\\"https://test.com/\\\"]}}\",\"folded\":0,\"meta_mac_address\":\"01:02:03:04:05:06\",\"endpoint_id\":\"a3288afe-799d-aizuef-azfeef-fazef\",\"schema_version\":\"20\",\"ioc_detection_mitre_attack\":\"[]\",\"ioc_detection_experiment_level\":0,\"ioc_detection_access\":\"{\\\"authentication\\\":\\\"None\\\",\\\"complexity\\\":\\\"Low\\\",\\\"vector\\\":\\\"Local\\\"}\",\"ioc_created_at\":\"2022-11-30T09:25:14.805Z\",\"ingestion_timestamp\":\"2022-11-30T09:22:45.391Z\",\"ioc_detection_attack\":\"Exposure\",\"numerics\":false,\"meta_public_ip\":\"1.2.3.4\",\"counter\":0,\"detection_id_dedup\":\"432025a1cb38ad65dc6azefazef\",\"meta_hostname\":\"AKAS-TE8789897\",\"ioc_detection_references\":\"[\\\"https://test.com\\\"]\",\"ioc_worker_name\":\"Direct Mapping Worker\",\"ioc_detection_type\":\"Vulnerability\",\"ioc_detection_category\":\"Vulnerability\",\"ioc_unix_time\":\"2022-11-30T09:22:25.000Z\",\"epoch\":1111100000,\"meta_ip_mask\":\"1.2.3.0\",\"ioc_worker_id\":\"direct_mapping_worker\",\"unix_time\":\"2022-11-30T09:22:25.000Z\",\"ioc_log_type\":\"summary\",\"query_source\":\"xdr_only\",\"host_identifier\":\"5C32B390-E1EB-D177\",\"partition_bucket\":\"87\",\"meta_boot_time\":1111100000,\"meta_os_name\":\"Microsoft Windows 10 Professionnel\",\"osquery_action\":\"added\",\"meta_query_pack_version\":\"1.14.90\",\"calendar_time\":\"2022-11-30T09:22:25.000Z\",\"meta_eid\":\"a3288afe-799d-46a4-9026-ad5cd41337f4\",\"ioc_detection_id\":\"COMPLIANCE-APP\",\"meta_os_platform\":\"windows\",\"meta_username\":\"AC7500JOIJOIJ\",\"detection_identifier\":\"09dd5e717aa664189d54ea1757ddd6e2beaacd676ffb\",\"query_name\":\"vulnerability_app_compatibility\",\"key\":\"LOCAL_MACHINE/Layers\",\"meta_os_version\":\"10.0.19044\",\"mtime\":1111100000,\"ioc_detection_licenses\":\"[\\\"MTR\\\"]\",\"name\":\"C:test.exe\",\"meta_aggressive_activity\":\"False\",\"meta_ip_address\":\"1.2.3.4\",\"type\":\"REG_SZ\",\"ingest_date\":\"2022-11-30\",\"ioc_detection_impact\":\"{\\\"availability\\\":\\\"Partial\\\",\\\"confidentiality\\\":\\\"Partial\\\",\\\"integrity\\\":\\\"Partial\\\"}\",\"meta_endpoint_type\":\"computer\",\"meta_domain_controller\":\"False\",\"customer_id\":\"f7193486-a186-4197\",\"data\":\"HIGHDPITEST\",\"ioc_detection_description\":\"Applications with special compatibility set for an executable.\",\"message_identifier\":\"75e420b40149f07eada47bdb23c28281\",\"ioc_attack_type\":\"Exposure\",\"ioc_detection_weight\":4}",
+        "event": {
+            "kind": "event",
+            "severity": 4,
+            "code": "COMPLIANCE-APP"
+        },
+        "@timestamp": "2022-11-30T09:22:25Z",
+        "user": {
+            "name": "AC7500JOIJOIJ"
+        },
+        "registry": {
+            "path": "LOCAL_MACHINE/test.exe",
+            "key": "LOCAL_MACHINE/Layers",
+            "data": {
+                "type": "REG_SZ",
+                "strings": [
+                    "HIGHDPITEST"
+                ]
+            }
+        },
+        "source": {
+            "ip": "1.2.3.4",
+            "mac": "01:02:03:04:05:06",
+            "address": "1.2.3.4"
+        },
+        "host": {
+            "name": "AKAS-TE8789897",
+            "id": "5C32B390-E1EB-D177",
+            "os": {
+                "name": "Microsoft Windows 10 Professionnel",
+                "version": "10.0.19044"
+            }
+        },
+        "vulnerability": {
+            "reference": "https://test.com",
+            "description": "Applications with special compatibility set for an executable."
+        },
+        "sophos": {
+            "threat_center": {
+                "cvss": "4",
+                "id": "a3288afe-799d-aizuef-azfeef-fazef",
+                "detection_attack": "Exposure",
+                "query": {
+                    "source": "xdr_only",
+                    "action": "added",
+                    "pack_version": "1.14.90",
+                    "name": "vulnerability_app_compatibility"
+                },
+                "endpoint": {
+                    "type": "computer"
+                }
+            }
+        },
+        "related": {
+            "ip": [
+                "1.2.3.4"
+            ],
+            "user": [
+                "AC7500JOIJOIJ"
+            ]
+        }
+    }
+    	
+	```
+
+
+=== "ioc_view_query2.json"
+
+    ```json
+	
+    {
+        "message": "{\"upload_size\":1869,\"record_identifier\":\"864de39eef32\",\"ioc_severity\":5,\"ioc_detection_sigma\":\"{\\\"id\\\":\\\"EVENT-Brute-Force-Attempt\\\",\\\"logsource\\\":{\\\"dedup_fields\\\":[\\\"machine_data.name\\\"],\\\"product\\\":\\\"windows\\\",\\\"platform\\\":\\\"windows\\\",\\\"category\\\":\\\"windows_event\\\",\\\"references\\\":[\\\"https://test.com/auditing/event-4625\\\"]}}\",\"folded\":0,\"meta_mac_address\":\"00:01:02:03:04:05\",\"endpoint_id\":\"51a8f1a0-db9d\",\"meta_public_ip_country_code\":\"FR\",\"remote_address\":\"1.2.3.4\",\"schema_version\":\"22\",\"authentication_package\":\"NTLM\",\"remote_port\":0,\"ioc_detection_mitre_attack\":\"[]\",\"ioc_detection_experiment_level\":0,\"ioc_created_at\":\"2023-07-17T11:34:57.524Z\",\"ingestion_timestamp\":\"2023-07-17T11:34:57.356Z\",\"ioc_detection_attack\":\"Suspicious Activity\",\"numerics\":false,\"eventid\":46254646,\"meta_public_ip\":\"1.2.3.4\",\"counter\":68,\"detection_id_dedup\":\"ab874753684df564365b\",\"logon_type\":3,\"meta_hostname\":\"mytestname-vm\",\"ioc_detection_references\":\"[\\\"https://test.com/auditing/event-4625\\\"]\",\"ioc_worker_name\":\"Direct Mapping Worker\",\"ioc_detection_type\":\"Threat\",\"ioc_detection_category\":\"Threat\",\"status\":\"0xc00000677d\",\"ioc_unix_time\":\"2023-07-17T11:34:45.000Z\",\"username_list\":\"TEST,TEST1,TEST2,TEST3,TEST4, TEST5\",\"epoch\":1689319838,\"event_timestamps\":\"1689589842,1689589974\",\"meta_ip_mask\":\"1.2.3.4\",\"meta_public_ip_city\":\"Camping\",\"failure_reason\":\"%%2313\",\"ioc_worker_id\":\"direct_mapping_worker\",\"transmitted_services\":\"-\",\"unix_time\":\"2023-07-17T11:34:45.000Z\",\"ioc_log_type\":\"summary\",\"query_source\":\"xdr_only\",\"host_identifier\":\"7BB240A3-B6AC\",\"partition_bucket\":\"10\",\"meta_public_ip_country\":\"France\",\"meta_public_ip_state\":\"Saint Paule\",\"meta_boot_time\":1687956677,\"subject_username\":\"-\",\"meta_os_name\":\"Microsoft Windows 10 Pro N\",\"osquery_action\":\"added\",\"meta_query_pack_version\":\"1.16.54\",\"subject_domain\":\"-\",\"calendar_time\":\"2023-07-17T11:34:45.000Z\",\"meta_eid\":\"51a8f1a0-db9d\",\"meta_public_ip_longitude\":-477.0565,\"ioc_detection_id\":\"EVENT-4625-Brute-Force-Attempt\",\"meta_os_platform\":\"windows\",\"detection_identifier\":\"864de39eef32e68379ce450f5b6ebd4ef7f1\",\"workstation_name\":\"-\",\"query_name\":\"windows_event_invalid_logon_brute_force\",\"key_length\":0,\"provider_name\":\"Microsoft-Windows-Security\",\"meta_os_version\":\"10.0.19044\",\"sub_status\":\"0xc0000064\",\"meta_public_ip_latitude\":-221.9035,\"source\":\"Security\",\"ioc_detection_licenses\":\"[\\\"MTR\\\",\\\"MTRE\\\"]\",\"name\":\"-\",\"description\":\"Source IP is shuffling through 20 or more different usernames, appears to be a brute force attack\",\"meta_aggressive_activity\":\"False\",\"meta_ip_address\":\"1.2.3.4\",\"logon_process\":\"NtLmSsp \",\"ingest_date\":\"2023-07-17\",\"target_domain\":\"\",\"meta_endpoint_type\":\"computer\",\"meta_domain_controller\":\"False\",\"customer_id\":\"4feff6df-7454\",\"ioc_detection_description\":\"Windows Event Brute Force Attempt Detected.\",\"message_identifier\":\"7f181e964e95390587e73b\",\"ioc_attack_type\":\"Suspicious Activity\",\"ioc_detection_weight\":5}",
+        "event": {
+            "kind": "event",
+            "severity": 5,
+            "reason": "Source IP is shuffling through 20 or more different usernames, appears to be a brute force attack",
+            "code": "EVENT-4625-Brute-Force-Attempt"
+        },
+        "@timestamp": "2023-07-17T11:34:45Z",
+        "registry": {
+            "data": {
+                "strings": [
+                    ""
+                ]
+            }
+        },
+        "source": {
+            "ip": "1.2.3.4",
+            "mac": "00:01:02:03:04:05",
+            "geo": {
+                "country_iso_code": "FR",
+                "city_name": "Camping",
+                "country_name": "France"
+            },
+            "address": "1.2.3.4"
+        },
+        "host": {
+            "name": "mytestname-vm",
+            "id": "7BB240A3-B6AC",
+            "os": {
+                "name": "Microsoft Windows 10 Pro N",
+                "version": "10.0.19044"
+            },
+            "domain": "-"
+        },
+        "vulnerability": {
+            "reference": "https://test.com/auditing/event-4625",
+            "description": "Windows Event Brute Force Attempt Detected."
+        },
+        "sophos": {
+            "threat_center": {
+                "id": "51a8f1a0-db9d",
+                "detection_attack": "Suspicious Activity",
+                "query": {
+                    "source": "xdr_only",
+                    "action": "added",
+                    "pack_version": "1.16.54",
+                    "name": "windows_event_invalid_logon_brute_force"
+                },
+                "endpoint": {
+                    "type": "computer"
+                }
+            }
+        },
+        "related": {
+            "ip": [
+                "1.2.3.4"
+            ]
+        }
+    }
+    	
+	```
+
+
+
+
+
+## Extracted Fields
+
+The following table lists the fields that are extracted, normalized under the ECS format, analyzed and indexed by the parser. It should be noted that infered fields are not listed.
+
+| Name | Type | Description                |
+| ---- | ---- | ---------------------------|
+|`@timestamp` | `date` | Date/time when the event originated. |
+|`event.code` | `keyword` | Identification code for this event. |
+|`event.kind` | `keyword` | The kind of the event. The highest categorization field in the hierarchy. |
+|`event.reason` | `keyword` | Reason why this event happened, according to the source |
+|`event.severity` | `long` | Numeric severity of the event. |
+|`host.domain` | `keyword` | Name of the directory the group is a member of. |
+|`host.id` | `keyword` | Unique host id. |
+|`host.name` | `keyword` | Name of the host. |
+|`host.os.name` | `keyword` | Operating system name, without the version. |
+|`host.os.version` | `keyword` | Operating system version as a raw string. |
+|`registry.data.strings` | `wildcard` | List of strings representing what was written to the registry. |
+|`registry.data.type` | `keyword` | Standard registry type for encoding contents |
+|`registry.key` | `keyword` | Hive-relative path of keys. |
+|`registry.path` | `keyword` | Full path, including hive, key and value |
+|`sophos.threat_center.cvss` | `keyword` | The Common Vulnerability Scoring System |
+|`sophos.threat_center.detection_attack` | `keyword` | The attack name |
+|`sophos.threat_center.endpoint.type` | `keyword` | The type of the endpoint |
+|`sophos.threat_center.id` | `keyword` | The identifier of the endpoint |
+|`sophos.threat_center.query.action` | `keyword` | The query action |
+|`sophos.threat_center.query.name` | `keyword` | The query name |
+|`sophos.threat_center.query.pack_version` | `keyword` | The query pack version |
+|`sophos.threat_center.query.source` | `keyword` | The query source |
+|`source.geo.city_name` | `keyword` | City name. |
+|`source.geo.country_iso_code` | `keyword` | Country ISO code. |
+|`source.geo.country_name` | `keyword` | Country name. |
+|`source.geo.postal_code` | `keyword` | Postal code. |
+|`source.ip` | `ip` | IP address of the source. |
+|`source.mac` | `keyword` | MAC address of the source. |
+|`user.name` | `keyword` | Short name or login of the user. |
+|`vulnerability.description` | `keyword` | Description of the vulnerability. |
+|`vulnerability.reference` | `keyword` | Reference of the vulnerability. |
+

--- a/_shared_content/operations_center/integrations/generated/bf8867ee-43b7-444c-9475-a7f43754ab6d.md
+++ b/_shared_content/operations_center/integrations/generated/bf8867ee-43b7-444c-9475-a7f43754ab6d.md
@@ -566,7 +566,7 @@ The following table lists the fields that are extracted, normalized under the EC
 |`vectra.detection.name` | `keyword` | The name of the detection |
 |`vectra.detection.namedpipe` | `keyword` | The named pipe. |
 |`vectra.detection.networks` | `keyword` | The target subnets. |
-|`vectra.detection.normal_admins` | `The normal admins observed.` | keyword |
+|`vectra.detection.normal_admins` | `keyword` | The normal admins observed. |
 |`vectra.detection.normal_servers` | `keyword` | The normal servers observed. |
 |`vectra.detection.num_attempts` | `keyword` | The number of attempts |
 |`vectra.detection.port` | `keyword` | The external port used. |

--- a/_shared_content/operations_center/integrations/generated/c10307ea-5dd1-45c6-85aa-2a6a900df99b.md
+++ b/_shared_content/operations_center/integrations/generated/c10307ea-5dd1-45c6-85aa-2a6a900df99b.md
@@ -169,6 +169,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             },
             "id": 4624
         },
+        "user": {
+            "target": {
+                "name": "FOO-FARM-ADMIN",
+                "domain": "FOOBAR.NET"
+            }
+        },
         "agent": {
             "id": "c1e16f64-cfc4-4141-bdc0-71f2a0e45791",
             "ephemeral_id": "21a6bd0d-afb5-4e55-827e-5329797579a4",
@@ -419,6 +425,8 @@ The following table lists the fields that are extracted, normalized under the EC
 |`event.provider` | `keyword` | Source of the event. |
 |`event.reason` | `keyword` | Reason why this event happened, according to the source |
 |`event.type` | `keyword` | Event type. The third categorization field in the hierarchy. |
+|`user.target.domain` | `keyword` | Name of the directory the user is a member of. |
+|`user.target.name` | `keyword` | Short name or login of the user. |
 |`winlog.activity_id` | `keyword` | A globally unique identifier that identifies the current activity. The events that are published with this identifier are part of the same activity. |
 |`winlog.provider_guid` | `keyword` | A globally unique identifier that identifies the provider that logged the event. |
 

--- a/_shared_content/operations_center/integrations/generated/ccf942fe-c839-42be-a081-5c3f946e80f5.md
+++ b/_shared_content/operations_center/integrations/generated/ccf942fe-c839-42be-a081-5c3f946e80f5.md
@@ -37,8 +37,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "message": "{ \"id\": \"00a8bc91-bd77-45d5-bf45-213c6b7fee19\", \"portal-id\": \"XXXXXX\", \"classification\": \"impersonating-domain-alert\", \"risk-assessment\": { \"risk-level\": \"low\" }, \"risk-factors\": [ \"Has assets in content\", \"Hosting content\", \"Has a DNS record\", \"Newly registered when raised\" ], \"title\": \"Impersonating Domain example.info\", \"description\": \"A domain that is possibly impersonating your assets was detected.\\n\\nRisk Level: Low\\nImpersonating Domain: example.info\\nLast Registered: \\n\\nRisk Factors:\\n* Has assets in content\\n* Hosting content\\n* Has a DNS record\\n* Newly registered when raised\\n\\nMatched Assets:\\n* example\\n* example.biz\\n* example.eu\\n* example.fr\\n\\n\\nWHOIS records provide the following information:\\nRegistrar: Epik, Inc.\\nRegistrar abuse contact email: donuts@epik.com\\nRegistrar abuse contact phone: 425-765-0077\\nCreated: 19 Feb 2021 16:35\\nLast updated: 21 Feb 2022 09:35\\nRegistrar registration expiration date: 19 Feb 2023 16:35\\n\\nDNS Record\\nA - 185.255.121.5\\nNS - ns3.epik.com.\\nNS - ns4.epik.com.\\nSOA - ns3.epik.com. support.epik.com. 2022022101 10800 3600 604800 3600\\nTXT - \\\"841f65603f47f3a7c35da7caf0f2ceaee92a1ed6\\\"\\nTXT - \\\"dan-ownership-verification=54z0h1kj\\\"\\nTXT - \\\"godaddyverification=Q8293uVVCXS1ttOuxPoOKg==\\\"\\n\\nAlert Raised: 05 Dec 2019 21:03\\nAlert Updated: 03 Mar 2022 13:03\\n\\nSearchlight Portal ID: XXXXX\\nSearchlight Portal Link: https://portal-digitalshadows.com/triage/alerts/XXXXX\\n\", \"assets\": [ { \"id\": \"76ab3f96-c12c-428d-b213-446f17b7ab9b\" }, { \"id\": \"5fa68b35-a58f-40de-b2af-74be78b45b2d\" }, { \"id\": \"1647634f-d3e4-4150-991a-a99d5682644b\" }, { \"id\": \"1bf42c15-4d9d-40cc-b63a-e6e9a08151dc\" } ], \"raised\": \"2019-12-05T21:03:10.433Z\", \"updated\": \"2022-03-03T13:03:51.044370Z\" }",
         "event": {
             "kind": "alert",
-            "category": "threat",
-            "type": "indicator",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "action": "impersonating-domain-alert",
             "reason": "Impersonating Domain example.info",
             "start": "2019-12-05T21:03:10.433000Z",
@@ -71,8 +75,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "message": "{\"id\":8484455,\"classification\":\"exposed-port-incident\",\"risk-level\":\"low\",\"title\":\"Exposed open port\",\"description\":\"The following ports have been detected on IP 11.22.33.44\\nPort 123\\n\",\"impact-description\":\"Port 123: Port 123 (Network Time Protocol) can be abused to cause a denial-of-service attack and should not be exposed to the public Internet.\\n\",\"mitigation\":\"Port 123: This port should ideally not be reachable from the public Internet and so should be firewalled off. In cases where this is not feasible, a technical compensating control could be the introduction of IP allowlisting of known IPs to prevent unauthorized access.\\t\\n\",\"assets\":[{\"id\":\"7332ea8f-cfbf-4bcf-8a1b-3b0991258dac\"}],\"raised\":\"2022-03-15T19:16:06.981Z\",\"updated\":\"2022-03-15T19:16:06.981Z\"}",
         "event": {
             "kind": "alert",
-            "category": "threat",
-            "type": "indicator",
+            "category": [
+                "threat"
+            ],
+            "type": [
+                "indicator"
+            ],
             "action": "exposed-port-incident",
             "reason": "Exposed open port",
             "start": "2022-03-15T19:16:06.981000Z",

--- a/_shared_content/operations_center/integrations/generated/d2725f97-0c7b-4942-a847-983f38efb8ff.md
+++ b/_shared_content/operations_center/integrations/generated/d2725f97-0c7b-4942-a847-983f38efb8ff.md
@@ -41,8 +41,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "kind": "event",
             "dataset": "Apex Execution",
-            "category": "network",
-            "type": "info"
+            "category": [
+                "network"
+            ],
+            "type": [
+                "info"
+            ]
         },
         "salesforce": {
             "method": {
@@ -71,8 +75,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "kind": "event",
             "dataset": "API",
-            "category": "network",
-            "type": "info"
+            "category": [
+                "network"
+            ],
+            "type": [
+                "info"
+            ]
         },
         "salesforce": {
             "api": {
@@ -101,8 +109,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "kind": "event",
             "dataset": "Audit Trail",
-            "category": "network",
-            "type": "info"
+            "category": [
+                "network"
+            ],
+            "type": [
+                "info"
+            ]
         },
         "user": {
             "name": "john.doe@example.com"
@@ -130,8 +142,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "start": "2016-08-18T23:59:48.642000Z",
             "code": "ltng:error",
             "action": "eventType",
-            "category": "network",
-            "type": "info",
+            "category": [
+                "network"
+            ],
+            "type": [
+                "info"
+            ],
             "duration": 123
         },
         "@timestamp": "2015-07-27T11:32:59.555000Z",
@@ -267,8 +283,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
             "start": "2016-08-18T23:59:48.642000Z",
             "code": "ltng:error",
             "action": "eventType",
-            "category": "network",
-            "type": "info",
+            "category": [
+                "network"
+            ],
+            "type": [
+                "info"
+            ],
             "duration": 123
         },
         "@timestamp": "2015-07-27T11:32:59.555000Z",
@@ -395,8 +415,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "kind": "event",
             "dataset": "Login",
-            "category": "network",
-            "type": "info"
+            "category": [
+                "network"
+            ],
+            "type": [
+                "info"
+            ]
         },
         "salesforce": {
             "login": {
@@ -432,8 +456,12 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
         "event": {
             "kind": "event",
             "dataset": "Report/Dashboard",
-            "category": "network",
-            "type": "info"
+            "category": [
+                "network"
+            ],
+            "type": [
+                "info"
+            ]
         },
         "user": {
             "name": "john.doe@example.com"

--- a/_shared_content/operations_center/integrations/generated/e4a758fc-7620-49e6-b8ed-b7fb3d7fa232.md
+++ b/_shared_content/operations_center/integrations/generated/e4a758fc-7620-49e6-b8ed-b7fb3d7fa232.md
@@ -36,9 +36,13 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
     {
         "message": "{\"id\": \"zekfnzejnf576rge8768\", \"date\": \"2022-02-10T13:00:05.454Z\", \"sender_ip\": \"192.168.1.1\", \"from\": \"test@sekoia.io\", \"from_header\": \"<test@sekoia.io>\", \"to\": \"test@vadesecure.com\", \"to_header\": \"\\\"test@vadesecure.com\\\" <test@vadesecure.com>\", \"subject\": \"Lorem ipsum dolor\", \"message_id\": \"<01de2305-f75b-49db-8c61-f661bd498e63.protection.outlook.com>\", \"urls\": [{\"url\": \"https://sekoia.io\"}], \"attachments\": [{\"id\": \"ca9ph2ostndl7735uht0\", \"filename\": \"image001.png\", \"extension\": \"png\", \"size\": 12894},{\"id\": \"ca9okt0kn1e8usdf633g\", \"filename\": \"archive.zip\", \"extension\": \"zip\", \"size\": 10558}], \"status\": \"LEGIT\", \"substatus\": \"\", \"remediation_type\": \"none\", \"remediation_ids\": [], \"action\": \"NOTHING\", \"folder\": \"\", \"size\": 113475, \"current_events\": [], \"whitelisted\": false}",
         "event": {
-            "category": "email",
+            "category": [
+                "email"
+            ],
             "kind": "event",
-            "type": "info",
+            "type": [
+                "info"
+            ],
             "action": "nothing"
         },
         "email": {
@@ -104,9 +108,13 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
     {
         "message": "{\"id\": \"ch34aoqub3glupige13g\", \"date\": \"2023-04-24T09:01:23.666Z\", \"sender_ip\": \"163.172.240.104\", \"from\": \"test@sekoia.io\", \"from_header\": \"Test SEKOIA.IO <test@sekoia.io>\", \"to\": \"test@vadesecure.com\", \"to_header\": \"\\\"test@vadesecure.com\\\" <test@vadesecure.com>\", \"subject\": \"OneDrive- Document No.: 1928578 - VadeSecure\", \"message_id\": \"<5b13d2f4-6078-4ae6-afa9-0d023b89e85a@MR2FRA01FT001.eop-fra01.prod.protection.outlook.com>\", \"urls\": [{\"url\": \"https://www.facebo\\u1ecdk.com/login.php\"}, {\"url\": \"https://www.facelbo?k.com/login.php\"}, {\"url\": \"https://www.vadesecure.com/\"}, {\"url\": \"https://sites.google.com/view/gine-office/home\"}], \"attachments\": [{\"id\": \"ch34aoqub3glupige170\", \"filename\": \"\", \"extension\": \"\", \"size\": 10558, \"hashes\": {\"md5\": \"7bc2b146a309acbff2da55e6b4124a82\", \"sha1\": \"299d5bf95adb52e640f9723c5f58b5a8e880be9b\", \"sha256\": \"288093f2981e53222135c94d1d6179a069d6e539daa86f10d65f86958f793368\", \"sha512\": \"7808b91ddf218cd9da382d42b2c5d07816964019976550f69aefe26182f6c324a5df8bafc9cd79167e09d4a339cfd33d5e7ba87342f459aae8e125fc64d42423\"}}, {\"id\": \"ch34aoqub3glupige17g\", \"filename\": \"\", \"extension\": \"\", \"size\": 12894, \"hashes\": {\"md5\": \"0eb4a83f99c2cd38d9d4decf809d1701\", \"sha1\": \"4665fcc8f1433dda8cd62d1234ead5ee32d4dd5f\", \"sha256\": \"f1e1783333718e2c937d7c694dacd518ccca9f219b31fbfda40e72ee16235dae\", \"sha512\": \"c6c817094c207e2d7bd12803a875bda79274fbac1c745a81dbd886d25c4147f179209073425a2e8b2f800ec3415376ef38eab64680ecb16ba9820ecde4ea8156\"}}], \"status\": \"PHISHING\", \"substatus\": \"\", \"last_report\": \"none\", \"last_report_date\": \"0001-01-01T00:00:00Z\", \"remediation_type\": \"none\", \"remediation_ids\": [], \"action\": \"MOVE\", \"folder\": \"JunkEmail\", \"size\": 186849, \"current_events\": [], \"whitelisted\": false, \"geo\": {\"country_name\": \"France\", \"country_iso_code\": \"FR\", \"city_name\": \"\"}, \"malware_bypass\": false}",
         "event": {
-            "category": "email",
+            "category": [
+                "email"
+            ],
             "kind": "event",
-            "type": "change",
+            "type": [
+                "change"
+            ],
             "action": "move"
         },
         "email": {
@@ -185,9 +193,13 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
     {
         "message": "{\"id\": \"cgrqlp83v5prkopmecf0\", \"date\": \"2023-04-13T07:10:29.191Z\", \"sender_ip\": \"163.172.240.104\", \"from\": \"test@sekoia.io\", \"from_header\": \"Test SEKOIA.IO <test@sekoia.io>\", \"to\": \"test@vadesecure.com\", \"to_header\": \"\\\"test@vadesecure.com\\\" <test@vadesecure.com>\", \"subject\": \"Lorem ipsum dolor\", \"message_id\": \"<d0a5da95-4028-439b-b9d5-a4f220c59022@protection.outlook.com>\", \"urls\": [], \"attachments\": [{\"id\": \"cgrqlp83v5prkopmecfg\", \"filename\": \"commande.docm\", \"extension\": \"docm\", \"size\": 96009, \"hashes\": {\"md5\": \"c1ea14accbb4f5ac66beac2d3f8de531\", \"sha1\": \"bfd1de0e780a3d7f047f6de00f44eaa1868e05e2\", \"sha256\": \"6ea92f15f697ef4c78ca02fd3d72b2531f047be00a588901b3d14578ccbd9424\", \"sha512\": \"77eec978ebbc455892fbce3dafe78140962c6c25a8050a9c9f0155b27ff1a08588cbf74bb41df49c1413431d307f099547354eabb7e5f23a798192a3c673749d\"}}], \"status\": \"LEGIT\", \"substatus\": \"\", \"last_report\": \"none\", \"last_report_date\": \"0001-01-01T00:00:00Z\", \"remediation_type\": \"none\", \"remediation_ids\": [], \"action\": \"NOTHING\", \"folder\": \"\", \"size\": 179355, \"current_events\": [], \"whitelisted\": true, \"geo\": {\"country_name\": \"France\", \"country_iso_code\": \"FR\", \"city_name\": \"\"}, \"malware_bypass\": true}",
         "event": {
-            "category": "email",
+            "category": [
+                "email"
+            ],
             "kind": "event",
-            "type": "info",
+            "type": [
+                "info"
+            ],
             "action": "nothing"
         },
         "email": {
@@ -248,9 +260,13 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
     {
         "message": "{\"id\": \"zekfnzejnf576rge8768\", \"date\": \"2022-02-01T23:30:33.982Z\", \"reason\": \"The email contains a URL that is flagged as Phishing by Vade Secure Global Threat Intelligence\", \"status\": {\"status\": \"PHISHING\"}, \"actions\": [{\"action\": \"MOVE\"}], \"nb_messages_remediated\": 1, \"nb_messages_remediated_read\": 0, \"nb_messages_remediated_unread\": 1}",
         "event": {
-            "category": "email",
+            "category": [
+                "email"
+            ],
             "kind": "event",
-            "type": "info",
+            "type": [
+                "info"
+            ],
             "reason": "The email contains a URL that is flagged as Phishing by Vade Secure Global Threat Intelligence"
         },
         "vadesecure": {
@@ -279,9 +295,13 @@ Find below few samples of events and how they are normalized by SEKOIA.IO.
     {
         "message": "{\"id\": \"zekfnzejnf576rge8768\", \"date\": \"2021-11-18T15:59:39.368Z\", \"reason\": \"\", \"actions\": [{\"action\": \"DELETE\"}, {\"action\": \"FAILED\"}], \"nb_messages_remediated\": 76, \"nb_messages_remediated_read\": 0, \"nb_messages_remediated_unread\": 76}",
         "event": {
-            "category": "email",
+            "category": [
+                "email"
+            ],
             "kind": "event",
-            "type": "info"
+            "type": [
+                "info"
+            ]
         },
         "vadesecure": {
             "campaign": {

--- a/scripts/update_mkdocs/update_mkdocs.py
+++ b/scripts/update_mkdocs/update_mkdocs.py
@@ -19,7 +19,7 @@ with open("ecs_flat.yml", "r") as fd:
 def analyze_parser(parser, custom_fields) -> Dict:
 
     taxonomy = ECS.copy()
-    taxonomy.update(custom_fields)
+    taxonomy.update(custom_fields or {})
     # extract all the fields
     fields = defaultdict(set)
     kind_values = set()
@@ -93,7 +93,7 @@ def load_intakes(intake_repository: str) -> List[Dict]:
             intake_fields = intake_path / "_meta" / "fields.yml"
             if intake_fields.exists():
                 with open(intake_fields, "r") as fd:
-                    intake["fields"] = yaml.safe_load(fd)
+                    intake["fields"] = yaml.safe_load(fd) or {}
             else:
                 intake["fields"] = {}
 


### PR DESCRIPTION
The script was failing from one week (see [Update intakes documentation GA](https://github.com/SEKOIA-IO/documentation/actions/workflows/update-intakes-documentation.yaml)) after fixing formats against some compliances.