### PR TITLE
fix(link-m365d): remove link for endpoints

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,7 +152,6 @@ nav:
           - HarfangLab: xdr/features/collect/integrations/endpoint/harfanglab.md
           - IBM AIX: xdr/features/collect/integrations/endpoint/ibm_aix.md
           - Linux: xdr/features/collect/integrations/endpoint/linux.md
-          - Microsoft Defender For Endpoints: xdr/features/collect/integrations/cloud_and_saas/office365/microsoft_365_defender.md
           - Microsoft Intune: xdr/features/collect/integrations/endpoint/microsoft_intune.md
           - Panda Security Aether: xdr/features/collect/integrations/endpoint/panda_security_aether.md
           - Sekoia.io Endpoint Agent: xdr/features/collect/integrations/endpoint/sekoiaio.md


### PR DESCRIPTION
I had to remove the link "Microsoft Defender for Endpoints" since the name was also written in the section "Microsoft 365 Defender" which is the right name for this product.