### PR TITLE
feat(auditbeat): modify for v8 and new file naming

### DIFF
--- a/docs/xdr/features/collect/integrations/endpoint/auditbeat_linux.md
+++ b/docs/xdr/features/collect/integrations/endpoint/auditbeat_linux.md
@@ -27,15 +27,15 @@ The following prerequisites are needed in order to setup efficient log concentra
 To download and install Auditbeat on a Debian based distributions (including Ubuntu, Linux Mint, etc.). Use the commands that work with your system:
 
 ```bash
-curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-7.13.1-amd64.deb
-sudo dpkg -i auditbeat-7.13.1-amd64.deb
+curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-8.11.4-amd64.deb
+sudo dpkg -i auditbeat-8.11.4-amd64.deb
 ```
 
 To download and install Auditbeat on Fedora, CentOS or Red Hat Enterprise Linux, use the commands that work with your system:
 
 ```bash
-curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-7.13.1-x86_64.rpm
-sudo rpm -vi auditbeat-7.13.1-x86_64.rpm
+curl -L -O https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-8.11.4-x86_64.rpm
+sudo rpm -vi auditbeat-8.11.4-x86_64.rpm
 ```
 
 > Modify the version number with the newest one.
@@ -243,16 +243,21 @@ input(type="imfile"
       File="/tmp/auditbeat/auditbeat"
       Tag="linux_auditbeat"
       Severity="info"
-      Facility="local7")
+      Facility="local7"
+      ruleset="auditbeatSekoia"
+      addMetadata="on"
+      )
 
-if ($syslogtag contains 'linux_auditbeat') then {
-     action(
-         type="omfwd"
-         protocol="tcp"
-         target="YOUR_RSYSLOG_DESTINATION_SERVER"
-         port="514"
-         TCP_Framing="octet-counted"
-     )
+ruleset(name="auditbeatSekoia") {
+    if (re_match($!metadata!filename, "auditbeat-[0-9]{8}.ndjson")) then {  
+      action(
+        type="omfwd"
+        protocol="tcp"
+        target="YOUR_RSYSLOG_DESTINATION_SERVER"
+        port="514"
+        TCP_Framing="octet-counted"
+      )
+    }
 }
 ```
 


### PR DESCRIPTION
Modify doc for Auditbeat v8.x.
Naming of files is now different when using `output.file`. If you define the name with `auditbeat`, the name will be in fact `auditbeat-{date}.ndjson`. It was needed to update Rsyslog config file in order to read only the file `auditbeat-{date}.ndjson` and not all the files that have been rotated by auditbeat.
I tried to have only one unique file instead of having 7 rotating file but that's not possible, the strict minimum is 2.

More information [here](https://www.elastic.co/guide/en/beats/auditbeat/current/file-output.html): 
<img width="861" alt="image" src="https://github.com/SEKOIA-IO/documentation/assets/90054310/0635a8ce-40ad-4a75-91ad-aa1cfd068068">
