### PR TITLE
PaloAlto: add disclaimer for timestamp

### DIFF
--- a/docs/xdr/features/collect/integrations/network/paloalto.md
+++ b/docs/xdr/features/collect/integrations/network/paloalto.md
@@ -19,6 +19,10 @@ On Palo Alto appliances, most of the important hardward and software activities 
 - System
 - Security
 
+!!! warning
+    Up to Palo Alto NGFW 10.0, the appliances must define UTC as their time zone, as the timestamp in the events is local time.
+    This requirement doesn't apply to appliances above 10.0.
+
 ### Create the intake on Sekoia.io
 
 Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a new intake from the format `Palo Alto Next-Generation Firewall`


### PR DESCRIPTION
Add a warning about the timezone of the timestamp in the events.

@MikeShvejk @ka0ula I'm not satisfied about the formulation; too directive in my opinion, but I failed to find a better way. I would like to explain that, up to version 10.0, the timestamp in events is local time and may result in a shift in the event page (as Sekoia.io only accept UTC timestamp). Do you have some suggestions? Thanks