### PR TITLE
fix(doc): FAQ url typo

### DIFF
--- a/docs/xdr/features/detect/built_in_detection_rules.md
+++ b/docs/xdr/features/detect/built_in_detection_rules.md
@@ -2,7 +2,7 @@
 
 Sekoia.io provides built-in detection rules to illuminate intrusions, adversarial behaviours and suspicious activity escalation chains so you can immediately take steps to remediate. Built-in rules can be customized to your context and according to your security posture.
 
-Please check the [dedicated FAQ page](/FAQ/Detection_qa.md) related to detection rule strategy.
+Please check the [dedicated FAQ page](/FAQ/Detection_qa/) related to detection rule strategy.
 
 For Windows-related rules, Sekoia.io automatically produces [this regularly updated list](built_in_detection_rules_eventids.md) of the needed EventIDs by rule but also globally as some statistics are provided.
 

--- a/docs/xdr/features/detect/rules_catalog.md
+++ b/docs/xdr/features/detect/rules_catalog.md
@@ -4,7 +4,7 @@ Once your event logs are collected and normalized by Sekoia.io, you probably wan
 
 All rules are applied to your event stream in real-time, so that you can detect - and respond to - threats as fast as possible.
 
-Please check the [dedicated FAQ page](/FAQ/Detection_qa.md) related to detection rule strategy.
+Please check the [dedicated FAQ page](/FAQ/Detection_qa/) related to detection rule strategy.
 
 ## Rule Types
 


### PR DESCRIPTION
New links to the new FAQ are broken.