### PR TITLE
Cisco: Refresh Cisco Umbrella documentations

### DIFF
--- a/_shared_content/operations_center/integrations/cisco_umbrella_set_aws_forwarding.md
+++ b/_shared_content/operations_center/integrations/cisco_umbrella_set_aws_forwarding.md
@@ -1,0 +1,68 @@
+This section will guide you to configure the forwarding of Cisco Umbrella logs to Sekoia.io by means of AWS S3 buckets.
+
+### Prerequities
+
+- Administrator access to the Cisco Umbrella console
+- Access to Sekoia.io Intakes and Playbook pages with write permissions
+- Access to AWS S3 and AWS SQS
+
+### Create an AWS S3 Bucket
+
+To create a new AWS S3 Bucket, please refer to [this guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html).
+
+1. On the AWS S3, go to `Buckets` and select our bucket.
+2. Select `Permissions` tab and go to `Bucket Policy` section
+3. Click `Edit` and paste [the JSON Bucket policy from Cisco Umbrella](https://docs.umbrella.com/deployment-umbrella/docs/setting-up-an-amazon-s3-bucket#json-bucket-policy)
+4. In the Policy, replace the `bucketname` placeholde by the name of our bucket.
+5. Click `Save changes`.
+
+!!! Important
+    Keep in mind to conserve the `/*` when defining in the policy.
+
+### Configure Cisco Umbrella
+
+1. Log on the Cisco Umbrella console
+2. Go to `Admin` > `Log Management`
+3. In the `Amazon S3` section, select `Use your company-managed Amazon S3 bucket`
+4. In `Amazon S3 bucket`, type the name of your bucket and click `Verify`.
+
+5. On your AWS console, go in your bucket.
+6. In the `Objects` tab, click on `README_FROM_UMBRELLA.txt` then click on `Open`
+7. Copy the token from the readme
+8. On the Cisco Umbrella console, in the field `Token Number`, paste the token and click `Save`
+
+!!! Note
+    After clicking `Verify`, the message `Great! We successfully verified your Amazon S3 bucket` must be displayed
+
+!!! Note
+    After clicking `Save`, the message `We’re sending data to your S3 storage` must be displayed
+
+!!! Important
+    According to the type of the logs, the objects will be prefixed with `dnslogs/` for DNS logs, `proxylogs` for proxy logs, `iplogs` for ip logs, ...
+
+### Create a SQS queue
+
+The collect will rely on S3 Event Notifications (SQS) to get new S3 objects.
+
+1. Create a queue in the SQS service by following [this guide](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-create-queue.html)
+2. In the Access Policy step, choose the advanced configuration and adapt this configuration sample with your own SQS Amazon Resource Name (ARN) (the main change is the Service directive allowing S3 bucket access):
+```json
+{
+  "Version": "2008-10-17",
+  "Id": "__default_policy_ID",
+  "Statement": [
+    {
+      "Sid": "__owner_statement",
+      "Effect": "Allow",
+      "Principal": {
+	"Service": "s3.amazonaws.com"
+      },
+      "Action": "SQS:SendMessage",
+      "Resource": "arn:aws:sqs:XXX:XXX"
+    }
+  ]
+}
+```
+
+!!! Important
+    Keep in mind that you have to create the SQS queue in the same region as the S3 bucket you want to watch.

--- a/docs/xdr/features/collect/integrations/cloud_and_saas/cisco_umbrella/umbrella_dns.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/cisco_umbrella/umbrella_dns.md
@@ -10,23 +10,32 @@ Cisco Umbrella offers flexible, cloud-delivered security. It combines multiple s
 {!_shared_content/operations_center/integrations/generated/90179796-f949-490c-8729-8cbc9c65be55.md!}
 
 ## Configure
-This setup guide will show you how to forward logs produced by CISCO Umbrella service to Sekoia.io by means of an Rsyslog transport channel.
 
-### Collect proxylogs files and send them to rsyslog
-After configuring Umbrella Log Management with AWS S3, the logs you download will be gzipped CSVs in appropriate subfolder with the following naming format:
+{!_shared_content/operations_center/integrations/cisco_umbrella_set_aws_forwarding.md!}
 
-```bash
-dnslogs/<year>-<month>-<day>/<year>-<month>-<day>-<hour>-<minute>.csv.gz
-```
+### Create a S3 Event notification
 
-To send these logs to Sekoia.io, we suggest the use of the logger Unix command. For each unzipped file, use the following command line:
 
-```bash
-logger -t dnslogs -f <YYYY>-<MM>-<DD>-<hh>-<mm>-<xxxx>.csv
-```
+Use the [following guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html) to create S3 Event Notification.
+Once created:
 
-### Configure the Rsyslog server
-Please consult the [Rsyslog Transport](../../../../ingestion_methods/syslog/overview/) documentation to forward these logs to Sekoia.io.
+1. In the General configuration, type `dnslogs/` as the Prefix
+2. Select the notification for object creation in the Event type section
+3. As the destination, choose the SQS service
+4. Select the queue you created in the previous section
+
+### Create the intake
+
+Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a new intake from the format `Cisco Umbrella DNS`.
+
+### Pull events
+
+To start to pull events, you have to: 
+
+1. Go to the [playbook page](https://app.sekoia.io/operations/playbooks) and create a new playbook with the [AWS Fetch new logs on S3 connector](../../../../automate/library/aws.md#fetch-new-logs-on-s3)
+2. Set up the module configuration with the [AWS Access Key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html), the secret key and the region name. Set up the trigger configuration with the name of the SQS queue and the intake key, from the intake previously created
+3. Start the playbook and enjoy your events
+
 
 ## Further Readings
-- [CISCO Umbrella User Guide - Logs Management](https://docs.umbrella.com/deployment-umbrella/docs/log-management)
+- [CISCO Umbrella User Guide - Manage your logs](https://docs.umbrella.com/deployment-umbrella/docs/setting-up-an-amazon-s3-bucket)

--- a/docs/xdr/features/collect/integrations/cloud_and_saas/cisco_umbrella/umbrella_ip.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/cisco_umbrella/umbrella_ip.md
@@ -8,24 +8,31 @@ Cisco Umbrella offers flexible, cloud-delivered security. It combines multiple s
 {!_shared_content/operations_center/integrations/generated/5cf6cc3b-50ca-48f5-a3ea-b9be92914fa2.md!}
 
 ## Configure
-This setup guide will show you how to forward logs produced by CISCO Umbrella service to Sekoia.io by means of an Rsyslog transport channel.
 
-### Collect proxylogs files and send them to rsyslog
-After configuring Umbrella Log Management with AWS S3, the logs you download will be gzipped CSVs in appropriate subfolder with the following naming format:
+{!_shared_content/operations_center/integrations/cisco_umbrella_set_aws_forwarding.md!}
 
-```bash
-iplogs/<year>-<month>-<day>/<year>-<month>-<day>-<hour>-<minute>.csv.gz
-```
+### Create a S3 Event notification
 
-To send these logs to Sekoia.io, we suggest the use of the logger Unix command. For each unzipped file, use the following command line:
 
-```bash
-logger -t iplogs -f <YYYY>-<MM>-<DD>-<hh>-<mm>-<xxxx>.csv
-```
+Use the [following guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html) to create S3 Event Notification.
+Once created:
 
-### Configure the Rsyslog server
-Please consult the [Rsyslog Transport](../../../../ingestion_methods/syslog/overview/) documentation to forward these logs to Sekoia.io.
+1. In the General configuration, type `iplogs/` as the Prefix
+2. Select the notification for object creation in the Event type section
+3. As the destination, choose the SQS service
+4. Select the queue you created in the previous section
 
+### Create the intake
+
+Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a new intake from the format `Cisco Umbrella IP`.
+
+### Pull events
+
+To start to pull events, you have to: 
+
+1. Go to the [playbook page](https://app.sekoia.io/operations/playbooks) and create a new playbook with the [AWS Fetch new logs on S3 connector](../../../../automate/library/aws.md#fetch-new-logs-on-s3)
+2. Set up the module configuration with the [AWS Access Key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html), the secret key and the region name. Set up the trigger configuration with the name of the SQS queue and the intake key, from the intake previously created
+3. Start the playbook and enjoy your events
 
 ## Further Readings
-- [CISCO Umbrella User Guide - Logs Management](https://docs.umbrella.com/deployment-umbrella/docs/log-management)
+- [CISCO Umbrella User Guide - Manage your logs](https://docs.umbrella.com/deployment-umbrella/docs/setting-up-an-amazon-s3-bucket)

--- a/docs/xdr/features/collect/integrations/cloud_and_saas/cisco_umbrella/umbrella_proxy.md
+++ b/docs/xdr/features/collect/integrations/cloud_and_saas/cisco_umbrella/umbrella_proxy.md
@@ -8,23 +8,32 @@ Cisco Umbrella offers flexible, cloud-delivered security. It combines multiple s
 {!_shared_content/operations_center/integrations/generated/5a8ef52f-d143-4735-8546-98539fc07725.md!}
 
 ## Configure
-This setup guide will show you how to forward logs produced by CISCO Umbrella service to Sekoia.io by means of an Rsyslog transport channel.
 
-### Collect proxylogs files and send them to rsyslog
-After configuring Umbrella Log Management with AWS S3, the logs you download will be gzipped CSVs in appropriate subfolder with the following naming format:
+{!_shared_content/operations_center/integrations/cisco_umbrella_set_aws_forwarding.md!}
 
-```bash
-proxylogs/<year>-<month>-<day>/<year>-<month>-<day>-<hour>-<minute>.csv.gz
-```
+### Create a S3 Event notification
 
-To send these logs to Sekoia.io, we suggest the use of the logger Unix command. For each unzipped file, use the following command line:
 
-```bash
-logger -t proxylogs -f <YYYY>-<MM>-<DD>-<hh>-<mm>-<xxxx>.csv
-```
+Use the [following guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html) to create S3 Event Notification.
+Once created:
 
-### Configure the Rsyslog server
-Please consult the [Rsyslog Transport](../../../../ingestion_methods/syslog/overview/) documentation to forward these logs to Sekoia.io.
+1. In the General configuration, type `dnslogs/` as the Prefix
+2. Select the notification for object creation in the Event type section
+3. As the destination, choose the SQS service
+4. Select the queue you created in the previous section
+
+### Create the intake
+
+Go to the [intake page](https://app.sekoia.io/operations/intakes) and create a new intake from the format `Cisco Umbrella Proxy`.
+
+### Pull events
+
+To start to pull events, you have to: 
+
+1. Go to the [playbook page](https://app.sekoia.io/operations/playbooks) and create a new playbook with the [AWS Fetch new logs on S3 connector](../../../../automate/library/aws.md#fetch-new-logs-on-s3)
+2. Set up the module configuration with the [AWS Access Key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html), the secret key and the region name. Set up the trigger configuration with the name of the SQS queue and the intake key, from the intake previously created
+3. Start the playbook and enjoy your events
+
 
 ## Further Readings
-- [CISCO Umbrella User Guide - Logs Management](https://docs.umbrella.com/deployment-umbrella/docs/log-management)
+- [CISCO Umbrella User Guide - Manage your logs](https://docs.umbrella.com/deployment-umbrella/docs/setting-up-an-amazon-s3-bucket)


### PR DESCRIPTION
update Cisco Umbrella documentation to use AWS S3 buckets to collect the events