### PR TITLE
Integration redirection: allow redirect to a same documentation from several formats

### DIFF
--- a/docs/integration/categories/network_security/gatewatcher_aioniq.md
+++ b/docs/integration/categories/network_security/gatewatcher_aioniq.md
@@ -1,4 +1,4 @@
-uuid: bba2bed2-d925-440f-a0ce-dbcae04eaf26
+uuid: bba2bed2-d925-440f-a0ce-dbcae04eaf26,2f28e4f9-a4f3-40a6-9909-b69f3df32535
 name: Gatewatcher AionIQ
 type: intake
 

--- a/plugins/intakes_by_uuid.py
+++ b/plugins/intakes_by_uuid.py
@@ -48,24 +48,25 @@ Redirecting...
                 if "uuid" not in metadata or metadata.get("type").lower() !=  "intake":
                     continue
 
-                dialect_uuid = metadata["uuid"]
+                dialect_uuids = (uuid.strip() for uuid in metadata["uuid"].split(","))
 
-                self._redirection_table[dialect_uuid] = source_file.url
-                self._integrations.append(
-                    {
-                        "uuid": dialect_uuid,
-                        "name": metadata.get("name"),
-                        "destination": source_file.url,
-                    }
-                )
+                for dialect_uuid in dialect_uuids:
+                    self._redirection_table[dialect_uuid] = source_file.url
+                    self._integrations.append(
+                        {
+                            "uuid": dialect_uuid,
+                            "name": metadata.get("name"),
+                            "destination": source_file.url,
+                        }
+                    )
 
-                newfile = File(
-                    path=f"operation_center/integration_catalog/uuid/{dialect_uuid}.md",
-                    src_dir="operation_center/integration_catalog/uuid",
-                    dest_dir=config["site_dir"],
-                    use_directory_urls=True,
-                )
-                new_files.append(newfile)
+                    newfile = File(
+                        path=f"operation_center/integration_catalog/uuid/{dialect_uuid}.md",
+                        src_dir="operation_center/integration_catalog/uuid",
+                        dest_dir=config["site_dir"],
+                        use_directory_urls=True,
+                    )
+                    new_files.append(newfile)
 
         new_files.append(File(
             path="integration/categories/index.md",


### PR DESCRIPTION
Add the ability to redirect to the same documentation when having several incompatible formats for a same product/integration.

e.g: For GateWatcher AIONIQ, we currently support two formats: The legacy one (V102) and the ECS-like format (v103).