### PR TITLE
Cloudflare: replace logpull_options by output_options

### DIFF
--- a/docs/integration/categories/applicative/cloudflare-audit-logs.md
+++ b/docs/integration/categories/applicative/cloudflare-audit-logs.md
@@ -39,7 +39,7 @@ $ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUN
     "enabled": true,
     "max_upload_bytes": 5000000,
     "max_upload_records": 1000,
-    "logpull_options":"fields=ActionResult,ActionType,ActorEmail,ActorID,ActorIP,ActorType,ID,Interface,Metadata,NewValue,OldValue,OwnerID,ResourceID,ResourceType,When&timestamps=rfc3339",
+    "output_options":"timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>"
     }' # (1)
 ```
@@ -58,7 +58,7 @@ $ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUN
     "max_upload_records": 1000,
     "enabled": true,
     "name": "<DOMAIN_NAME>",
-    "logpull_options": "fields=<LIST_OF_FIELDS>",
+    "output_options": "timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>",
     "last_complete": null,
     "last_error": null,

--- a/docs/integration/categories/network/cloudflare-access-requests.md
+++ b/docs/integration/categories/network/cloudflare-access-requests.md
@@ -39,7 +39,7 @@ $ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUN
     "enabled": true,
     "max_upload_bytes": 5000000,
     "max_upload_records": 1000,
-    "logpull_options":"fields=Action,Allowed,AppDomain,AppUUID,Connection,Country,CreatedAt,Email,IPAddress,PurposeJustificationPrompt,PurposeJustificationResponse,RayID,TemporaryAccessApprovers,TemporaryAccessDuration,UserUID&timestamps=rfc3339",
+    "output_options":"timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>"
     }' # (1)
 ```
@@ -58,7 +58,7 @@ $ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUN
     "max_upload_records": 1000,
     "enabled": true,
     "name": "<DOMAIN_NAME>",
-    "logpull_options": "fields=<LIST_OF_FIELDS>",
+    "output_options":"timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>",
     "last_complete": null,
     "last_error": null,

--- a/docs/integration/categories/network/cloudflare-dns-logs.md
+++ b/docs/integration/categories/network/cloudflare-dns-logs.md
@@ -39,7 +39,7 @@ $ curl -X POST https://api.cloudflare.com/client/v4/zones/<CLOUDFLARE_ZONE_ID>/l
     "enabled": true,
     "max_upload_bytes": 5000000,
     "max_upload_records": 1000,
-    "logpull_options":"fields=ColoCode,EDNSSubnet,EDNSSubnetLength,QueryName,QueryType,ResponseCached,ResponseCode,SourceIP,Timestamp&timestamps=unix",
+    "output_options":"timestamp_format=unix",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>"
 }' # (1)
 ```
@@ -54,7 +54,7 @@ $ curl -X POST https://api.cloudflare.com/client/v4/zones/<CLOUDFLARE_ZONE_ID>/l
     "dataset": "dns_log",
     "enabled": false,
     "name": "<DOMAIN_NAME>",
-    "logpull_options": "fields=<LIST_OF_FIELDS>=rfc3339",
+    "output_options":"timestamp_format=unix",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>",
     "last_complete": null,
     "last_error": null,

--- a/docs/integration/categories/network/cloudflare-gateway-dns.md
+++ b/docs/integration/categories/network/cloudflare-gateway-dns.md
@@ -39,7 +39,7 @@ $ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUN
     "enabled": true,
     "max_upload_bytes": 5000000,
     "max_upload_records": 1000,
-    "logpull_options":"fields=ApplicationID,ColoCode,ColoID,Datetime,DeviceID,DeviceName,DstIP,DstPort,Email,Location,LocationID,MatchedCategoryIDs,MatchedCategoryNames,Policy,PolicyID,Protocol,QueryCategoryIDs,QueryCategoryNames,QueryName,QueryNameReversed,QuerySize,QueryType,QueryTypeName,RCode,RData,ResolvedIPs,ResolverDecision,SrcIP,SrcPort,TimeZone,TimeZoneInferredMethod,UserID&timestamps=rfc3339",
+    "output_options":"timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>"
     }' # (1)
 ```
@@ -58,7 +58,7 @@ $ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUN
     "max_upload_records": 1000,
     "enabled": true,
     "name": "<DOMAIN_NAME>",
-    "logpull_options": "fields=<LIST_OF_FIELDS>",
+    "output_options":"timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>",
     "last_complete": null,
     "last_error": null,

--- a/docs/integration/categories/network/cloudflare-gateway-http.md
+++ b/docs/integration/categories/network/cloudflare-gateway-http.md
@@ -39,7 +39,7 @@ $ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUN
     "enabled": true,
     "max_upload_bytes": 5000000,
     "max_upload_records": 1000,
-    "logpull_options":"fields=AccountID,Action,BlockedFileHash,BlockedFileName,BlockedFileReason,BlockedFileSize,BlockedFileType,Datetime,DestinationIP,DestinationPort,DeviceID,DeviceName,DownloadedFileNames,Email,FileInfo,HTTPHost,HTTPMethod,HTTPStatusCode,HTTPVersion,IsIsolated,PolicyID,PolicyName,Referer,RequestID,SourceIP,SourceInternalIP,SourcePort,URL,UntrustedCertificateAction,UploadedFileNames,UserAgent,UserID&timestamps=rfc3339",
+    "output_options":"timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>"
     }' # (1)
 ```
@@ -58,7 +58,7 @@ $ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUN
     "max_upload_records": 1000,
     "enabled": true,
     "name": "<DOMAIN_NAME>",
-    "logpull_options": "fields=<LIST_OF_FIELDS>",
+    "output_options":"timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>",
     "last_complete": null,
     "last_error": null,

--- a/docs/integration/categories/network/cloudflare-gateway-network.md
+++ b/docs/integration/categories/network/cloudflare-gateway-network.md
@@ -39,7 +39,7 @@ $ curl -X POST https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUNT
     "enabled": true,
     "max_upload_bytes": 5000000,
     "max_upload_records": 1000,
-    "logpull_options":"fields=AccountID,Action,Datetime,DestinationIP,DestinationPort,DeviceID,DeviceName,Email,OverrideIP,OverridePort,PolicyID,PolicyName,SNI,SessionID,SourceIP,SourceInternalIP,SourcePort,Transport,UserID&timestamps=rfc3339",
+    "output_options":"timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>"
 }' # (1)
 ```
@@ -58,7 +58,7 @@ $ curl -X POST https://api.cloudflare.com/client/v4/accounts/<CLOUDFLARE_ACCOUNT
     "max_upload_records": 1000,
     "enabled": true,
     "name": null,
-    "logpull_options": "fields=<LIST_OF_FIELDS>",
+    "output_options":"timestamp_format=rfc3339",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>",
     "last_complete": null,
     "last_error": null,

--- a/docs/integration/categories/network/cloudflare-http-requests.md
+++ b/docs/integration/categories/network/cloudflare-http-requests.md
@@ -38,7 +38,7 @@ $ curl -X POST https://api.cloudflare.com/client/v4/zones/<CLOUDFLARE_ZONE_ID>/l
     "enabled": true,
     "max_upload_bytes": 5000000,
     "max_upload_records": 1000,
-    "logpull_options":"fields=ClientIP,ClientRequestHost,ClientRequestMethod,ClientRequestURI,EdgeEndTimestamp,EdgeResponseBytes,EdgeResponseStatus,EdgeStartTimestamp,RayID&timestamps=unix",
+    "output_options":"timestamp_format=unix",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>"
 }' # (1)
 ```
@@ -53,7 +53,7 @@ $ curl -X POST https://api.cloudflare.com/client/v4/zones/<CLOUDFLARE_ZONE_ID>/l
     "dataset": "http_requests",
     "enabled": false,
     "name": "<DOMAIN_NAME>",
-    "logpull_options": "fields=<LIST_OF_FIELDS>&timestamps=rfc3339",
+    "output_options":"timestamp_format=unix",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>",
     "last_complete": null,
     "last_error": null,

--- a/docs/integration/categories/network_security/cloudflare-firewall-events.md
+++ b/docs/integration/categories/network_security/cloudflare-firewall-events.md
@@ -38,7 +38,7 @@ $ curl -X POST https://api.cloudflare.com/client/v4/zones/<CLOUDFLARE_ZONE_ID>/l
     "enabled": true,
     "max_upload_bytes": 5000000,
     "max_upload_records": 1000,
-    "logpull_options":"fields=Action,ClientASN,ClientASNDescription,ClientCountry,ClientIP,ClientIPClass,ClientRefererHost,ClientRefererPath,ClientRefererQuery,ClientRefererScheme,ClientRequestHost,ClientRequestMethod,ClientRequestPath,ClientRequestProtocol,ClientRequestQuery,ClientRequestScheme,ClientRequestUserAgent,Datetime,EdgeColoCode,EdgeResponseStatus,Kind,MatchIndex,Metadata,OriginResponseStatus,OriginatorRayID,RayID,RuleID,Source&timestamps=unix",
+    "output_options":"timestamp_format=unix",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>"
 }' # (1)
 ```
@@ -53,7 +53,7 @@ $ curl -X POST https://api.cloudflare.com/client/v4/zones/<CLOUDFLARE_ZONE_ID>/l
     "dataset": "firewall_events",
     "enabled": false,
     "name": "<DOMAIN_NAME>",
-    "logpull_options": "fields=<LIST_OF_FIELDS>&timestamps=rfc3339",
+    "output_options":"timestamp_format=unix",
     "destination_conf": "https://intake.sekoia.io/plain/batch?header_X-SEKOIAIO-INTAKE-KEY=<YOUR_INTAKE_KEY>",
     "last_complete": null,
     "last_error": null,


### PR DESCRIPTION
- replace logpull_options by output_options as the first one is now deprecated in the CloudFlare LogPush API (see [documentation](https://developers.cloudflare.com/api/resources/logpush/subresources/jobs/methods/create/#(params)%200%20%3E%20(param)%20enabled%20%3E%20(schema))
- remove the fields as it settles the fields of the events in the configuration and prevent getting new ones when added by Cloudflare.