### PR TITLE
Update events_query_language.md - corrected advanded``by ``advanced

### DIFF
--- a/docs/xdr/features/investigate/events_query_language.md
+++ b/docs/xdr/features/investigate/events_query_language.md
@@ -1,6 +1,6 @@
 # Events Query Language
 
-This domain-specific language can be used to generate search queries that integrate advanded search operators.
+This domain-specific language can be used to generate search queries that integrate advanced search operators.
 
 Please refer to [Elastic Common Schema (ECS) Reference](https://www.elastic.co/docs/reference/ecs/ecs-field-reference) if you need to look up a field available in Sekoia.io. 
 


### PR DESCRIPTION
On the first line: This domain-specific language can be used to generate search queries that integrate advanded search operators.

I changed ``advanded``by ``advanced``




Changed