### PR TITLE
Add selinux instructions for relp

### DIFF
--- a/docs/integration/ingestion_methods/syslog/rsyslog.md
+++ b/docs/integration/ingestion_methods/syslog/rsyslog.md
@@ -451,8 +451,9 @@ Follow these steps to forward logs using RELP Protocol:
 	    )
 	}
 	```
-	 !!!note
-   		If selinux is enabled and set to enforcing, port 11514 needs to be added to 'syslog_tls_port_t'. Run `sudo semanage port -a -t syslog_tls_port_t -p tcp 11514`
+
+!!!note
+    If selinux is enabled and set to enforcing, port 11514 needs to be added to 'syslog_tls_port_t'. Run `sudo semanage port -a -t syslog_tls_port_t -p tcp 11514`
 
 
 ## Troubleshooting

--- a/docs/integration/ingestion_methods/syslog/rsyslog.md
+++ b/docs/integration/ingestion_methods/syslog/rsyslog.md
@@ -451,6 +451,9 @@ Follow these steps to forward logs using RELP Protocol:
 	    )
 	}
 	```
+	 !!!note
+   		If selinux is enabled and set to enforcing, port 11514 needs to be added to 'syslog_tls_port_t'. Run `sudo semanage port -a -t syslog_tls_port_t -p tcp 11514`
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
added noteblock with instructions for allowing syslog to communicate to port 11514