### PR TITLE
Intake TLS certificate

### DIFF
--- a/docs/integration/categories/applicative/microsoft_iis.md
+++ b/docs/integration/categories/applicative/microsoft_iis.md
@@ -96,14 +96,13 @@ To get started with NXLog, follow these steps:
 
 #### Download the certificate
 
-To enable the connection between your events forwarder and the [Sekoia.io](http://sekoia.io/) intake, it is necessary to download the [Sekoia.io](http://sekoia.io/) intake certificate. Please follow these steps:
+To enable the connection between your events forwarder and the [Sekoia.io](http://sekoia.io/) intake, it is necessary to download the [`IRG ROOT X1` certificate](https://letsencrypt.org/certs/isrgrootx1.pem). Please follow these steps:
 
 1. Open a PowerShell console as an administrator.
 2. Use the following command to retrieve the certificate and save it to the appropriate directory:
     
     ```powershell
-     Invoke-WebRequest -Uri <https://app.sekoia.io/assets/files/SEKOIA-IO-intake.pem> -OutFile 'C:\\Program Files\\nxlog\\cert\\Sekoia.io-intake.pem'
-    
+     Invoke-WebRequest -Uri https://letsencrypt.org/certs/isrgrootx1.pem -OutFile 'C:\\Program Files\\nxlog\\cert\\isgrootx1.pem'
     ```
     
 3. Restart the NXLog service through the Services tool as an administrator or use the following PowerShell command line as an administrator:

--- a/docs/integration/categories/endpoint/windows.md
+++ b/docs/integration/categories/endpoint/windows.md
@@ -115,12 +115,12 @@ To get started with NXLog, follow these steps:
 
 ### Download the certificate
 
-To enable the connection between your events forwarder and the Sekoia.io intake, it is necessary to download the Sekoia.io intake certificate. Please follow these steps:
+To enable the connection between your events forwarder and the Sekoia.io intake, it is necessary to download the [`IRG ROOT X1` certificate](https://letsencrypt.org/certs/isrgrootx1.pem). Please follow these steps:
 
 1. Open a PowerShell console as an administrator.
 2. Use the following command to retrieve the certificate and save it to the appropriate directory:
    ```powershell
-    Invoke-WebRequest -Uri https://app.sekoia.io/assets/files/SEKOIA-IO-intake.pem -OutFile 'C:\Program Files\nxlog\cert\Sekoia.io-intake.pem'
+    Invoke-WebRequest -Uri https://letsencrypt.org/certs/isrgrootx1.pem -OutFile 'C:\\Program Files\\nxlog\\cert\\isgrootx1.pem'
     ```
 
 3. Restart the NXLog service through the Services tool as an administrator or use the following PowerShell command line as an administrator:

--- a/docs/integration/categories/iam/rubycat_prove_it.md
+++ b/docs/integration/categories/iam/rubycat_prove_it.md
@@ -37,9 +37,6 @@ sudo vim /etc/rsyslog.d/46-proveit.conf
 Paste the following rsyslog configuration to trigger the emission of Pulse Connect Secure logs by your Rsyslog server to Sekoia.io:
 
 ```bash
-# Define the SEKIOA-IO intake certificate
-$DefaultNetstreamDriverCAFile /etc/rsyslog.d/Sekoia.io-intake.pem
-
 # Configure up the network ssl connection
 $ActionSendStreamDriver gtls # use gtls netstream driver
 $ActionSendStreamDriverMode 1 # require TLS for the connection
@@ -74,3 +71,18 @@ Go to the [events page](https://app.sekoia.io/operations/events) to watch your i
 {!_shared_content/operations_center/detection/generated/suggested_rules_d6f69e04-6ab7-40c0-9723-84060aeb5529_do_not_edit_manually.md!}
 {!_shared_content/operations_center/integrations/generated/d6f69e04-6ab7-40c0-9723-84060aeb5529.md!}
 
+## Troubleshooting
+
+### TLS error: Rsyslog cannot authenticate the Sekoia.io syslog endpoint
+
+The Sekoia.io syslog endpoint is secured with a [Letsencrypt](https://letsencrypt.org) certificate.
+
+According to our installation, it may be necessary to install `ISRG ROOT X1` certificate in our **trusted root certification authorities certificate store**:
+
+1. Download the `IRG ROOT X1` certificate: <https://letsencrypt.org/certs/isrgrootx1.pem>
+
+```bash
+$ wget https://letsencrypt.org/certs/isrgrootx1.pem -O /tmp/isrgrootx1.pem
+```
+
+2. Move the certificate to the relevant directory (e.g., `/etc/ssl/certs` for Debian-based distributions, `/etc/pki/tls/certs` for Red Hat-based distributions; please refer to the documentation of your operating system distribution)

--- a/docs/integration/categories/network_security/stormshield_network_security.md
+++ b/docs/integration/categories/network_security/stormshield_network_security.md
@@ -30,7 +30,7 @@ This section will guide you to forward Stormshield SNS logs to Sekoia.
 
 #### Import the intake certificate
 
-On a device, please download the [Sekoia.io intake certificate](https://app.sekoia.io/assets/files/SEKOIA-IO-intake.pem)
+On a device, please download the `IRG ROOT X1` certificate: <https://letsencrypt.org/certs/isrgrootx1.pem>
 
 1. Log on the UTM administration console
 2. Click `Configuration` tab

--- a/docs/integration/ingestion_methods/syslog/rsyslog.md
+++ b/docs/integration/ingestion_methods/syslog/rsyslog.md
@@ -49,13 +49,7 @@ After receiving the IDs to connect to the Linux server, the main activities are 
         sudo dnf install -y rsyslog rsyslog-gnutls wget
 	    ```
 
-3. Download the Sekoia.io certificate
-
-	```bash
-	sudo wget -O /etc/rsyslog.d/Sekoia-io-intake.pem https://app.sekoia.io/assets/files/SEKOIA-IO-intake.pem
-	```
-
-4. Modify the `/etc/rsyslog.conf` main configuration file
+3. Modify the `/etc/rsyslog.conf` main configuration file
 
 	This is an example of standard configuration file.
     In this file:
@@ -108,7 +102,7 @@ After receiving the IDs to connect to the Linux server, the main activities are 
 	*.*;auth,authpriv.none          -/var/log/syslog
 	```
 
-5. Verify your configuration file is correct
+4. Verify your configuration file is correct
 
     ```bash
     rsyslogd -N1
@@ -117,7 +111,7 @@ After receiving the IDs to connect to the Linux server, the main activities are 
     !!!note
         Rsyslogd may not be in your distribution PATH. It is usually found in `/sbin/rsyslogd`
 
-6. Restart Rsyslog service and check its status
+5. Restart Rsyslog service and check its status
 
 	```bash
 	sudo systemctl restart rsyslog
@@ -169,7 +163,6 @@ In this section, let suppose that Windows event logs are sent to the Rsyslog on 
     To this ruleset, an action is defined to tell Rsyslog that all incoming messages associated to it must be forwarded to the Sekoia.io syslog endpoint on a specific Intake. Please change using the YOUR_INTAKE_KEY accordingly.
 
     ```bash
-    $DefaultNetstreamDriverCAFile /etc/rsyslog.d/Sekoia-io-intake.pem
     input(type="imtcp" port="20516" ruleset="remote20516")
 
     template(name="SEKOIAIOWindowsTemplate" type="string" string="<%pri%>1 %timestamp:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"YOUR_INTAKE_KEY\"] %msg%\n")
@@ -583,6 +576,21 @@ It is possible to test your specific `if` condition. To do so:
 4. Restart the Rsyslog service
 5. Remove the `/var/log/testing.log` file and `/var/log/troubleshoot.log` file if necessary
 
+### 5- TLS error: Rsyslog cannot authenticate the Sekoia.io syslog endpoint
+
+The Sekoia.io syslog endpoint is secured with a [Letsencrypt](https://letsencrypt.org) certificate.
+
+According to our installation, it may be necessary to install `ISRG ROOT X1` certificate in our **trusted root certification authorities certificate store**:
+
+1. Download the `IRG ROOT X1` certificate: <https://letsencrypt.org/certs/isrgrootx1.pem>
+
+```bash
+$ wget https://letsencrypt.org/certs/isrgrootx1.pem -O /tmp/isrgrootx1.pem
+```
+
+2. Move the certificate to the relevant directory (e.g., `/etc/ssl/certs` for Debian-based distributions, `/etc/pki/tls/certs` for Red Hat-based distributions; please refer to the documentation of your operating system distribution)
+
+
 ## Example of auto-setup configuration
 
 In order to help users setting up this concentrator, the following bash script working for Ubuntu or Debian server is recommended.
@@ -670,9 +678,6 @@ It will automatically configure you Rsyslog server to collect and forward Window
 	    )
 	}
 	EOM
-
-	# Collect the SEKOIA Key for encryption between Rsyslog and Sekoia.io
-	sudo wget -O /etc/rsyslog.d/Sekoia-io-intake.pem https://app.sekoia.io/assets/files/SEKOIA-IO-intake.pem
 	```
 
 2. Once the file created on the Rsyslog, make it executable with the command `chmod +x <filename.sh>`.

--- a/docs/integration/ingestion_methods/syslog/syslog-ng.md
+++ b/docs/integration/ingestion_methods/syslog/syslog-ng.md
@@ -13,11 +13,8 @@ To proceed, you can execute the following commands in your favorite shell:
 ```
 sudo mkdir -p /etc/syslog-ng/ca.d
 
-# Retrieve Sekoia.io’s Certificate Authority (Let’s Encrypt)
-sudo wget -O /etc/syslog-ng/ca.d/Sekoia.io-intake.pem https://app.sekoia.io/assets/files/SEKOIA-IO-intake.pem
-
-# Split PEM file into multiples PEM files (one for each certificate containes in `Sekoia.io-intake.pem`).
-sudo awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "cert." c ".pem"}' < Sekoia.io-intake.pem
+# Retrieve Certificate Authority (Let’s Encrypt)
+sudo wget -O /etc/syslog-ng/ca.d/isgrootx1.pem https://letsencrypt.org/certs/isrgrootx1.pem
 
 # Ask OpenSSL to create a hash for each PEM file.
 sudo openssl rehash /etc/syslog-ng/ca.d


### PR DESCRIPTION
Update the documentation to remove the old SEKOIA-IO-Intake.pem certificate and replace it by isgrootx1.pem when needed.