### PR TITLE
Update sekoia_operating_language.md

### DIFF
--- a/docs/xdr/features/investigate/sekoia_operating_language.md
+++ b/docs/xdr/features/investigate/sekoia_operating_language.md
@@ -1684,8 +1684,7 @@ events
 | project host.name, total_count
 
 ```
-`project` and `select` are aliases. They are exactly the same command
-
+Please note: the `select` command can also be used. `select` and `project` are aliases and both return the same results.
 ---
 
 ### host.os.type per Sekoia endpoint agent


### PR DESCRIPTION
replaced:
"project and select are aliases. They are exactly the same command"

by

"Please note: the select command can also be used. Select and project are aliases and both return the same results."