### PR TITLE
chore(doc): use common syslog endpoint

### DIFF
--- a/docs/getting_started/regions.md
+++ b/docs/getting_started/regions.md
@@ -50,7 +50,7 @@ For companies wishing to host their data in France:
         </tr>
         <tr>
             <td>Syslog RELP Intake</td>
-            <td><a href="app.sekoia.io:11514">app.sekoia.io:11514</a></td>
+            <td><a href="intake.sekoia.io:11514">app.sekoia.io:11514</a></td>
         </tr>
     </tbody>
 </table>

--- a/docs/integration/ingestion_methods/index.md
+++ b/docs/integration/ingestion_methods/index.md
@@ -12,7 +12,7 @@ Sekoia.io supports the following log collecting methods:
 
 - [HTTPS](/integration/ingestion_methods/https/overview.md) (`https://intake.sekoia.io`): `POST` your JSON events to Sekoia.io.
 - [Syslog](/integration/ingestion_methods/syslog/overview.md) over TLS (`intake.sekoia.io:10514`): forward your events with the Syslog protocol specified in RFC 5424.
-- [RELP](/integration/ingestion_methods/syslog/rsyslog.md#how-to-forward-logs-to-sekoiaio-using-relp) over TLS (`relp.intake.sekoia.io:11514`): forward your events with Rsyslog's reliable protocol called RELP.
+- [RELP](/integration/ingestion_methods/syslog/rsyslog.md#how-to-forward-logs-to-sekoiaio-using-relp) over TLS (`intake.sekoia.io:11514`): forward your events with Rsyslog's reliable protocol called RELP.
 - [NetFlow](/integration/ingestion_methods/netflow/sekoiaio_netflow_concentrator.md): collect and forward NetFlow data from network devices using our NetFlow concentrator.
 - [Cloud hosting and API polling](/integration/ingestion_methods/cloud_saas/overview.md): configure Sekoia.io to regularly retrieve your logs.
 

--- a/docs/integration/ingestion_methods/syslog/rsyslog.md
+++ b/docs/integration/ingestion_methods/syslog/rsyslog.md
@@ -408,7 +408,7 @@ Before processing, you have to:
 - Add an Intake to the relevant Entity
 - Keep trace of the automatically generated Intake key
 
-To forward events using this acknowledge protocol to Sekoia.io, you have to send events using TLS to `relp.intake.sekoia.io` and to respect the RFC 5426. Additionally, you need to update the syslog header with the intake key you created earlier.
+To forward events using this acknowledge protocol to Sekoia.io, you have to send events using TLS to `intake.sekoia.io` and to respect the RFC 5426. Additionally, you need to update the syslog header with the intake key you created earlier.
 
 The most noticeable change using RELP in Rsyslog is the output module used (`omrelp`).
 
@@ -434,12 +434,12 @@ Follow these steps to forward logs using RELP Protocol:
 	if ($programname startswith 'unbound') then {
 	  action(
 		type="omrelp"
-		target="relp.intake.sekoia.io"
+		target="intake.sekoia.io"
 		port="11514"
 		tls="on"
 		tls.caCert="/etc/rsyslog.d/Sekoia-io-intake.pem"
 		tls.authmode="name"
-		tls.permittedPeer=["relp.intake.sekoia.io"]
+		tls.permittedPeer=["intake.sekoia.io"]
 		template="SEKOIAIOUnboundTemplate"
 	    )
 	}


### PR DESCRIPTION
# Description

- Replace `relp.intake.sekoia.io` to `intake.sekoia.io` as it's the same endpoint