### PR TITLE
Sophos Threat Analysis center - add note about api host

### DIFF
--- a/docs/integration/categories/network_security/sophos_threat_analysis_center.md
+++ b/docs/integration/categories/network_security/sophos_threat_analysis_center.md
@@ -67,7 +67,7 @@ To enable hydrating the data lake for server:
 2. Set the intake account configuration with the `client_id` and `client_secret` from the Sophos console.
 
     !!! info
-        - If you want to change the region with your own region, you can find your region via **protect devices field**, first click on **Protect Devices**, Then copy link of any download links and finally Check the region that appears as part of the URL.
+        - No need to change the **API Url of the Sophos Central API**
         - No need to change the **Oauth2 Authorization Url** for the moment (this's the only endpoint to get a JWT token).
 
 3. In the intake configuration section choose a `frequency` - Default is `60` -.


### PR DESCRIPTION
https://github.com/SekoiaLab/integration/issues/1189

Added a note about api host - we don't need to change the field (at least in common circumstances) because we acquire the correct regional endpoint with `/whoami` request

Field description will be updated in https://github.com/SekoiaLab/integration/issues/1176