### PR TITLE
Introduce feedback collection

### DIFF
--- a/docs/javascript/posthog.js
+++ b/docs/javascript/posthog.js
@@ -1,4 +1,29 @@
 window.addEventListener("DOMContentLoaded", (event) => {
+    
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('phc_adBekSlnN2US9CpINrlyXZ651aXRMdReihHA5pi2Jdt',{api_host:'https://eu.posthog.com', "opt_in_site_apps": true,})
+    posthog.init('phc_adBekSlnN2US9CpINrlyXZ651aXRMdReihHA5pi2Jdt',{api_host:'https://eu.posthog.com', "opt_in_site_apps": true,});
+
+    // posthog surveys IDs
+    const SURVEY_ID_UP = "019baa85-6cd8-0000-0919-c62dbbfa7e8f";
+    const SURVEY_ID_DOWN = "019baa83-c271-0000-4550-e787f0a88e4e";
+
+    document.addEventListener(
+        "click",
+        (e) => {
+            const el = e.target.closest(".docs-feedback");
+            if (!el) return;
+
+            e.preventDefault();
+
+            const vote = el.dataset.vote; // "up" | "down"
+
+            // 3) Show instantly (no waiting for event-based condition evaluation)
+            const surveyId = vote === "up" ? SURVEY_ID_UP : SURVEY_ID_DOWN;
+
+            if (typeof posthog.displaySurvey === "function") {
+                posthog.displaySurvey(surveyId);
+            }
+        },
+        true
+    );
 });

--- a/docs/stylesheets/posthog.css
+++ b/docs/stylesheets/posthog.css
@@ -1,0 +1,67 @@
+/* --- Page feedback card under ToC --- */
+.toc-card[data-component="toc-card"] {
+  margin-top: 1rem;
+  padding: 1rem;
+}
+
+/* Title */
+.toc-card__title {
+  margin: 0 0 .75rem 0;
+  font-weight: 700;
+  font-size: .7rem;
+  line-height: 1.2;
+  color: var(--md-default-fg-color);
+}
+
+/* Buttons row */
+.toc-card__actions {
+  display: flex;
+  gap: .5rem;
+}
+
+/* Buttons */
+.toc-card__btn.docs-page-feedback__btn.docs-feedback {
+  display: inline-flex;
+  align-items: center;
+  gap: .4rem;
+
+  padding: .1rem .7rem;
+  border-radius: .5rem;
+
+  border: 1px solid var(--md-primary-fg-color);
+  background: transparent;
+  color: var(--md-primary-fg-color);
+
+  font-weight: 600;
+  font-size: .5rem;
+  line-height: 1;
+
+  cursor: pointer;
+  user-select: none;
+}
+
+/* Hover/focus */
+.toc-card__btn.docs-page-feedback__btn.docs-feedback:hover {
+  background: color-mix(in srgb, var(--md-primary-fg-color) 10%, transparent);
+}
+
+.toc-card__btn.docs-page-feedback__btn.docs-feedback:focus-visible {
+  outline: 2px solid var(--md-primary-fg-color);
+  outline-offset: 2px;
+}
+
+/* Pressed */
+.toc-card__btn.docs-page-feedback__btn.docs-feedback:active {
+  transform: translateY(1px);
+}
+
+/* Icon sizing */
+.toc-card__icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* Optional: visual state if your JS toggles aria-pressed="true" */
+.toc-card__btn[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--md-primary-fg-color) 14%, transparent);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ extra_css:
 - stylesheets/lightgallery.min.css
 - stylesheets/poppins.min.css
 - stylesheets/inter.min.css
+- stylesheets/posthog.css
 extra_javascript:
 - javascript/sekoiaio.js
 - javascript/lightgallery.min.js

--- a/theme/partials/toc.html
+++ b/theme/partials/toc.html
@@ -1,0 +1,79 @@
+<!--
+  Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Determine title -->
+{% set title = lang.t("toc") %}
+{% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
+  {% set title = config.mdx_configs.toc.title %}
+{% endif %}
+
+<!-- Table of contents -->
+<nav class="md-nav md-nav--secondary" aria-label="{{ title | e }}">
+  {% set toc = page.toc %}
+
+  <!--
+    Check whether the content starts with a level 1 headline. If it does, the
+    top-level anchor must be skipped, since it would be redundant to the link
+    to the current page that is located just above the anchor. Therefore we
+    directly continue with the children of the anchor.
+  -->
+  {% set first = toc | first %}
+  {% if first and first.level == 1 %}
+    {% set toc = first.children %}
+  {% endif %}
+
+  <!-- Table of contents title and list -->
+  {% if toc %}
+    <label class="md-nav__title" for="__toc">
+      <span class="md-nav__icon md-icon"></span>
+      {{ title }}
+    </label>
+    <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
+      {% for toc_item in toc %}
+        {% include "partials/toc-item.html" %}
+      {% endfor %}
+    </ul>
+
+    <!-- Page feedback (an extension to the original code of M. Donath) -->
+    <div class="toc-card" data-component="toc-card">
+      <div class="toc-card__title">Was this page helpful?</div>
+
+      <div class="toc-card__actions">
+        <button class="toc-card__btn docs-page-feedback__btn docs-feedback" type="button" data-vote="up" aria-label="Helpful">
+          <span class="toc-card__icon">
+            {% include ".icons/material/thumb-up-outline.svg" %}
+          </span>
+          Yes
+        </button>
+
+        <button class="toc-card__btn docs-page-feedback__btn docs-feedback" type="button" data-vote="down" aria-label="Not helpful">
+          <span class="toc-card__icon">
+            {% include ".icons/material/thumb-down-outline.svg" %}
+          </span>
+          No
+        </button>
+      </div>
+    </div>
+
+  {% endif %}
+</nav>
+


### PR DESCRIPTION
This PR enables the collection of user feedbacks on every page.

Using the partials mecanism of mkdocs templating, we override the table of content definition to include
a feedback html/css code to ask the question if the page is usefull.

Via a js function, we attach a listener to each buttons (yes or no) that triggers the adequate posthog survey.
The two surveys are also created.

<img width="1579" height="1245" alt="image" src="https://github.com/user-attachments/assets/236f8617-be24-4262-b3fa-2b8a311831bb" />

<img width="325" height="436" alt="image" src="https://github.com/user-attachments/assets/008eed62-1c64-4162-8d8c-7df0db5d93b6" />
