### PR TITLE
GA: fix the github workflow that refresh the intakes documentation

### DIFF
--- a/.github/workflows/update-intakes-documentation.yaml
+++ b/.github/workflows/update-intakes-documentation.yaml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [rebuild-intake-documentation]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since the begining of the month, all jobs fails (see [jobs](https://github.com/SEKOIA-IO/documentation/actions/workflows/update-intakes-documentation.yaml))