### PR TITLE
feat: Add a warning announcement in previews

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -17,6 +17,10 @@ jobs:
         with:
           python-version: '3.14'
 
+      - name: Add “preview” banner
+        run: |
+          mv theme/main_preview.html theme/main.html
+
       - name: Make destination directory for compiled CSS
         run: mkdir -vp docs/stylesheets/
 

--- a/style/sekoiaio.scss
+++ b/style/sekoiaio.scss
@@ -542,3 +542,8 @@
 %tabbed-content {
   display: block;
 }
+
+.md-banner {
+    background: #ffff53;
+    color: black;
+}

--- a/theme/main_preview.html
+++ b/theme/main_preview.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+{{ super() }}
+<meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block announce %}
+<b>This is a draft version of Sekoia.io documentation. Please use the <a href="https://docs.sekoia.io/">official Sekoia.io documentation</a> to have an up-to-date information.</b>
+{% endblock %}


### PR DESCRIPTION
Add a banner in all generated previews with a link to the official documentation.

<img width="1786" height="369" alt="image" src="https://github.com/user-attachments/assets/fa604b4e-ace0-45c2-bc04-d94eccf7f76d" />
