### PR TITLE
fix(sigma): correct indentation for condition in non_working_hours_utc

### DIFF
--- a/docs/xdr/features/detect/sigma.md
+++ b/docs/xdr/features/detect/sigma.md
@@ -326,7 +326,7 @@ detection:
     event.code: 4720
   non_working_hours_utc:
 	  timestamp|timerange: 20:00-09:00
-	condition: selection and non_working_hours_utc
+  condition: selection and non_working_hours_utc
 ```
 
 ### Day of week


### PR DESCRIPTION
There was a tab instead of two spaces so the indentation of the sigma rule wasn't correct