### PR TITLE
GitHub Actions: Fix “spellchecking” workflow

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -14,30 +14,25 @@ env:
   CLICOLOR: 1
 
 jobs:
-  find-docs:
-    name: Find intakes in repo
+  spelling:
+    name: Spell Check with Typos
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.list-changed-docs.outputs.matrix }}
     steps:
       - name: Check-out the repo under $GITHUB_WORKSPACE
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - id: list-changed-docs
-        name: List changed documentations
-        run: |
-          echo "matrix=$(comm -12 <(git diff --name-only -r HEAD^1 HEAD | sort | uniq) <(find docs -type f -name '*.md' ! -path 'docs/assets/**' | sort))" >> $GITHUB_OUTPUT
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
+        with:
+          use_rest_api: true
+          files: |
+            docs/**/*.md
+            !docs/assets/**/*
 
-  spelling:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    needs: find-docs
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Spell Check Repo
         uses: crate-ci/typos@57b11c6b7e54c402ccd9cda953f1072ec4f78e33 # v1.43.5
         with:
-          files: ${{ needs.find-docs.outputs.matrix }}
+          files: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
Simplify the “spelling” GitHub Actions workflow:
- Move to a single job workflow (single checkout).
- Use `tj-actions/changed-files` to identify changes Markdown files in the PR.