### PR TITLE
Netskope: deprecate the old Netskope Transaction Events integration

### DIFF
--- a/docs/integration/categories/network_security/netskope_transaction.md
+++ b/docs/integration/categories/network_security/netskope_transaction.md
@@ -4,6 +4,9 @@ type: intake
 
 ## Overview
 
+!!! Warning
+    This integration is deprecated in favor of [Netskope Log Streaming](netskope_log_streaming.md) and will be removed next.
+
 [Netskope](https://www.netskope.com/) is a cybersecurity company that provides solutions to protect data in cloud apps and network security while applying zero trust principles.
 
 - **Vendor**: Netskope

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -404,7 +404,7 @@ nav:
       - NeroSwarm Honeypot: integration/categories/network_security/neroswarm_honeypot.md
       - Netskope Events: integration/categories/network_security/netskope_events.md
       - Netskope Log Streaming (Transaction Events): integration/categories/network_security/netskope_log_streaming.md
-      - Netskope Transaction Events: integration/categories/network_security/netskope_transaction.md
+      - Netskope Transaction Events [DEPRECATED]: integration/categories/network_security/netskope_transaction.md
       - Nozomi Vantage: integration/categories/network_security/nozomi_vantage.md
       - OGO Shield WAF: integration/categories/network_security/ogo_shield.md
       - Olfeo SAAS: integration/categories/network_security/olfeo_saas.md


### PR DESCRIPTION
This integration is overriden by the Netskope Log Streaming as the underlying technology for Netskope Transaction Events (i.e Google PubSub Lite) will be turned down on March 18th (see [Google documentation](https://docs.cloud.google.com/pubsub/lite/docs)).