### PR TITLE
chore(dependabot): monitor local composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,9 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     # Cooldown applies only to version updates, not security updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,9 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/**/*"
     schedule:
       interval: "weekly"
     # Cooldown applies only to version updates, not security updates


### PR DESCRIPTION
## Summary
- Switch the github-actions Dependabot entry from `directory` to `directories` and add `/.github/actions/*`
- This ensures dependencies in `.github/actions/delete-preview/action.yaml` are tracked for version and security updates
- Follow-up to #2877 which hardened the workflows but missed covering the local composite action in Dependabot

## Test plan
- [ ] Verify Dependabot picks up the new directories and creates PRs for outdated actions in `.github/actions/`