### PR TITLE
fix/align_doc_on_various_regions

### DIFF
--- a/_shared_content/automate/playbooks-on-premises.md
+++ b/_shared_content/automate/playbooks-on-premises.md
@@ -71,6 +71,11 @@ To ensure a bug-free installation, the Sekoia Endpoint Agent must be able to com
     - minio-symphony.prod.sekoia.io
     - ...
 
+!!! note
+    The domains listed above apply to the **FRA1** region.
+    For other regions, the agent will communicate with region-specific endpoints (e.g., `app.fra2.sekoia.io`, `api.fra2.sekoia.io` for FRA2 region).
+    The required domains for your region are displayed during the playbook runner installation in the Sekoia.io interface.
+
 ### Testing the prerequisites
 
 We've prepared a Docker image to facilitate the validation process and ensure the environment is properly configured for agent installation.
@@ -83,7 +88,7 @@ docker run ghcr.io/sekoia-io/hello-sekoia:latest
 
 This command will initiate the image download, effectively verifying whether the host system can successfully access the Docker registry and establish connectivity with Sekoia.io.
 
-Here's an example of the expected output for your reference:
+Here's an example of the expected output for your reference (FRA1 region):
 
 ```
 Checking container runs in Docker ... OK
@@ -96,7 +101,7 @@ Checking connectivity with the object storage ... OK
 !!! tip
     The `-e` option can be passed to the docker command to specify:
 
-    * The region: `-e region=mco1`
+    * The region: `-e region=<region>`, where `<region>` is one of: `fra1`, `fra2`, `mco1`, `uae1`, `usa1`, `sgp1`
     * Proxy information: `-e https_proxy={proxy_url}`
 
 
@@ -120,7 +125,7 @@ To create a playbook runner, follow these steps:
 Your newly created playbook runner should now appear in the list. It will also be shown when configuring any playbook action.
 
 !!! tip
-    To specify a region when installing the runner, the `--region` argument can be added to the command.
+    To specify a region when installing the runner, add the `--region` argument to the installation command. Accepted values are: `fra1`, `fra2`, `mco1`, `uae1`, `usa1`, `sgp1`.
 
 ### Use a runner in a playbook action
 

--- a/_shared_content/automate/playbooks-on-premises.md
+++ b/_shared_content/automate/playbooks-on-premises.md
@@ -101,9 +101,10 @@ Checking connectivity with the object storage ... OK
 !!! tip
     The `-e` option can be passed to the docker command to specify:
 
-    * The region: `-e region=<region>`, where `<region>` is one of `fra1`, `fra2`, `mco1`, `uae1`, `usa1`, `sgp1` (e.g., `-e region=mco1` for MCO1 region)
+    * The region: `-e region=<region>` (e.g., `-e region=mco1` for MCO1 region)
     * Proxy information: `-e https_proxy=<proxy_url>`
 
+The Sekoia regions are listed and documented [here](https://docs.sekoia.io/getting_started/regions/)
 
 ## Playbook runners
 
@@ -125,7 +126,7 @@ To create a playbook runner, follow these steps:
 Your newly created playbook runner should now appear in the list. It will also be shown when configuring any playbook action.
 
 !!! tip
-    To specify a region when installing the runner, add the `--region` argument to the installation command. Accepted values are: `fra1`, `fra2`, `mco1`, `uae1`, `usa1`, `sgp1`.
+    To specify a region when installing the runner, add the `--region` argument to the installation command.
 
 ### Use a runner in a playbook action
 

--- a/_shared_content/automate/playbooks-on-premises.md
+++ b/_shared_content/automate/playbooks-on-premises.md
@@ -88,15 +88,15 @@ docker run ghcr.io/sekoia-io/hello-sekoia:latest
 
 This command will initiate the image download, effectively verifying whether the host system can successfully access the Docker registry and establish connectivity with Sekoia.io.
 
-Here's an example of the expected output for your reference (FRA1 region):
+??? example "Example of the expected output (FRA1 region):"
 
-```
-Checking container runs in Docker ... OK
-Checking connectivity with Sekoia.io APIs ...
-  - Checking app.sekoia.io ... OK
-  - Checking api.sekoia.io ... OK
-Checking connectivity with the object storage ... OK
-```
+    ```
+    Checking container runs in Docker ... OK
+    Checking connectivity with Sekoia.io APIs ...
+    - Checking app.sekoia.io ... OK
+    - Checking api.sekoia.io ... OK
+    Checking connectivity with the object storage ... OK
+    ```
 
 !!! tip
     The `-e` option can be passed to the docker command to specify:
@@ -104,7 +104,8 @@ Checking connectivity with the object storage ... OK
     * The region: `-e region=<region>` (e.g., `-e region=mco1` for MCO1 region)
     * Proxy information: `-e https_proxy=<proxy_url>`
 
-The Sekoia regions are listed and documented [here](https://docs.sekoia.io/getting_started/regions/)
+!!! tip
+    Learn more about region and code in [our dedicated article](/getting_started/regions.md).
 
 ## Playbook runners
 
@@ -127,6 +128,9 @@ Your newly created playbook runner should now appear in the list. It will also b
 
 !!! tip
     To specify a region when installing the runner, add the `--region` argument to the installation command.
+
+!!! tip
+    Learn more about region and code in [our dedicated article](/getting_started/regions.md).
 
 ### Use a runner in a playbook action
 

--- a/_shared_content/automate/playbooks-on-premises.md
+++ b/_shared_content/automate/playbooks-on-premises.md
@@ -101,8 +101,8 @@ Checking connectivity with the object storage ... OK
 !!! tip
     The `-e` option can be passed to the docker command to specify:
 
-    * The region: `-e region=<region>`, where `<region>` is one of: `fra1`, `fra2`, `mco1`, `uae1`, `usa1`, `sgp1`
-    * Proxy information: `-e https_proxy={proxy_url}`
+    * The region: `-e region=<region>`, where `<region>` is one of `fra1`, `fra2`, `mco1`, `uae1`, `usa1`, `sgp1` (e.g., `-e region=mco1` for MCO1 region)
+    * Proxy information: `-e https_proxy=<proxy_url>`
 
 
 ## Playbook runners

--- a/docs/integration/ingestion_methods/https/format.md
+++ b/docs/integration/ingestion_methods/https/format.md
@@ -1,18 +1,51 @@
 # Formatting options
 
-To forward logs to Sekoia.io, several options format are available:
+To forward logs to Sekoia.io, several formatting options are available:
 
 - Send your events as line-oriented records
 - Send your events as a JSON object
 - Send your events as a structured payload
 
-For each option, we will have to supply an intake key. The collector endpoint of Sekoia.io will provide event identifiers within the Sekoia.io detection workflow in the form of a JSON payload.
+For each option, we have to supply an intake key. The collector endpoint of Sekoia.io will provide event identifiers within the Sekoia.io detection workflow in the form of a JSON payload.
+
+## Select the intake endpoint for your region
+
+Sekoia.io supports multiple regions for HTTP ingestion.
+
+FRA1 keeps the historical URL scheme, while all other regions use the new API-prefixed scheme.
+
+Use the right endpoint for your region:
+
+| Region | Endpoint |
+|--------|-------------------|
+| FRA1 | `https://intake.sekoia.io/<path>` |
+| FRA2 | `https://intake.fra2.io/api/v1/intake-http/<path>` |
+| MC01 | `https://intake.mc01.io/api/v1/intake-http/<path>` |
+| UAE1 | `https://intake.uae1.io/api/v1/intake-http/<path>` |
+| USA1 | `https://intake.usa1.io/api/v1/intake-http/<path>` |
+| SGP1 | `https://intake.sgp1.io/api/v1/intake-http/<path>` |
+
+To derive other ingestion paths `/<path>` from this page, use:
+
+- FRA1 base URL: `https://intake.sekoia.io`
+- Other regions base URL: `https://intake.<region>.io/api/v1/intake-http`
+
+Then append the path `/<path>` (examples: `/plain`, `/plain/batch`, `/jsons`, `/batch`, `/array`, etc.) to the corresponding regional base URL.
+
+Examples:
+- `https://intake.sekoia.io/batch`
+- `https://intake.fra2.io/api/v1/intake-http/batch`
+- `https://intake.mc01.io/api/v1/intake-http/jsons`
+- `https://intake.uae1.io/api/v1/intake-http/plain/batch`
+
+!!! warning
+    The examples below use FRA1 URLs for readability. For other regions, replace the base URL with your regional endpoint.
 
 ## Push our events to Sekoia.io as line-oriented records
 
 To forward events as plain records, you can use the `/plain` endpoint.
 
-The following headers are handled by Sekoia.io’S HTTPS log collector:
+The following headers are handled by Sekoia.io's HTTPS log collector:
 
 | Header                       | Mandatory? | Type     | Description                                                                            |
 |------------------------------|------------|----------|----------------------------------------------------------------------------------------|
@@ -20,7 +53,7 @@ The following headers are handled by Sekoia.io’S HTTPS log collector:
 | `X-SEKOIAIO-EVENT-TIMESTAMP` | No         | Datetime | Event date if you want to push your own date (fallback is to use the reception’s date) |
 
 
-Supply the intake key as the header `X-SEKOIAIO-INTAKE-KEY`, as password in the HTTP Basic authentication mechanism or as a parameter in the querystring.
+Supply the intake key as the header `X-SEKOIAIO-INTAKE-KEY`, as password in the HTTP Basic authentication mechanism, or as a parameter in the query string.
 
 To push one event, just POST content to `https://intake.sekoia.io/plain`
 
@@ -121,7 +154,7 @@ curl -X POST -H "X-SEKOIAIO-INTAKE-KEY: REPLACE_BY_INTAKE_KEY" --data-binary @ev
 
 To send us events as a JSON list, you should set `Content-Type` HTTP header to `application/json`.
 
-The following headers are handled by Sekoia.io’S HTTPS log collector:
+The following headers are handled by Sekoia.io's HTTPS log collector:
 
 | Header                       | Mandatory? | Type     | Description                                                                            |
 |------------------------------|------------|----------|----------------------------------------------------------------------------------------|
@@ -129,7 +162,7 @@ The following headers are handled by Sekoia.io’S HTTPS log collector:
 | `X-SEKOIAIO-EVENT-TIMESTAMP` | No         | Datetime | Event date if you want to push your own date (fallback is to use the reception’s date) |
 
 
-Supply the intake key as the header `X-SEKOIAIO-INTAKE-KEY`, as password in the HTTP Basic authentication mechanism or as a parameter in the querystring.
+Supply the intake key as the header `X-SEKOIAIO-INTAKE-KEY`, as password in the HTTP Basic authentication mechanism, or as a parameter in the query string.
 
 Use the endpoint `/jsons`. This endpoint accepts a set of events:
 
@@ -223,11 +256,11 @@ If your events are enclosed in a JSON object, use the endpoint `/jsons` and prov
 
 To send us events, you should set `Content-Type` HTTP header to `application/json`.
 
-The following fields are currently handled by Sekoia.io’S HTTPS log collector:
+The following fields are currently handled by Sekoia.io's HTTPS log collector:
 
 | Field         | Mandatory? | Type     | Description                                                                                            |
 |---------------|------------|----------|--------------------------------------------------------------------------------------------------------|
-| `intakey_key` | Yes        | String   | Intake to which you would like to push events to                                                       |
+| `intake_key`  | Yes        | String   | Intake to which you would like to push events to                                                       |
 | `json`        | Yes        | String   | The actual log payload. If you want to push structured JSON logs, please send them as quoted JSON here |
 | `@timestamp`  | No         | Datetime | Event date if you want to push your own date (fallback is to use the reception’s date)                 |
 

--- a/docs/integration/ingestion_methods/https/format.md
+++ b/docs/integration/ingestion_methods/https/format.md
@@ -14,7 +14,8 @@ Sekoia.io supports multiple regions for HTTP ingestion.
 
 FRA1 keeps the historical URL scheme, while all other regions use the new API-prefixed scheme.
 
-The Sekoia regions are listed and documented [here](https://docs.sekoia.io/getting_started/regions/)
+!!! tip
+    Learn more about region and code in [our dedicated article](/getting_started/regions.md).
 
 Endpoints must be built from regional base URLs:
 

--- a/docs/integration/ingestion_methods/https/format.md
+++ b/docs/integration/ingestion_methods/https/format.md
@@ -14,25 +14,17 @@ Sekoia.io supports multiple regions for HTTP ingestion.
 
 FRA1 keeps the historical URL scheme, while all other regions use the new API-prefixed scheme.
 
-Use the right endpoint for your region:
+The Sekoia regions are listed and documented [here](https://docs.sekoia.io/getting_started/regions/)
 
-| Region | Endpoint |
-|--------|-------------------|
-| FRA1 | `https://intake.sekoia.io/<path>` |
-| FRA2 | `https://intake.fra2.sekoia.io/api/v1/intake-http/<path>` |
-| MCO1 | `https://intake.mco1.sekoia.io/api/v1/intake-http/<path>` |
-| UAE1 | `https://intake.uae1.sekoia.io/api/v1/intake-http/<path>` |
-| USA1 | `https://intake.usa1.sekoia.io/api/v1/intake-http/<path>` |
-| SGP1 | `https://intake.sgp1.sekoia.io/api/v1/intake-http/<path>` |
-
-To derive other ingestion paths `/<path>` from this page, use:
+Endpoints must be built from regional base URLs:
 
 - FRA1 base URL: `https://intake.sekoia.io`
 - Other regions base URL: `https://intake.<region>.sekoia.io/api/v1/intake-http`
 
-Then append the path `/<path>` (examples: `/plain`, `/plain/batch`, `/jsons`, `/batch`, `/array`, etc.) to the corresponding regional base URL.
+Then append the path `/<path>` (e.g., `/plain`, `/plain/batch`, `/jsons`, `/batch`, `/array`, etc.) to the corresponding regional base URL.
 
 Examples:
+
 - `https://intake.sekoia.io/batch`
 - `https://intake.fra2.sekoia.io/api/v1/intake-http/batch`
 - `https://intake.mco1.sekoia.io/api/v1/intake-http/jsons`

--- a/docs/integration/ingestion_methods/https/format.md
+++ b/docs/integration/ingestion_methods/https/format.md
@@ -19,24 +19,24 @@ Use the right endpoint for your region:
 | Region | Endpoint |
 |--------|-------------------|
 | FRA1 | `https://intake.sekoia.io/<path>` |
-| FRA2 | `https://intake.fra2.io/api/v1/intake-http/<path>` |
-| MC01 | `https://intake.mc01.io/api/v1/intake-http/<path>` |
-| UAE1 | `https://intake.uae1.io/api/v1/intake-http/<path>` |
-| USA1 | `https://intake.usa1.io/api/v1/intake-http/<path>` |
-| SGP1 | `https://intake.sgp1.io/api/v1/intake-http/<path>` |
+| FRA2 | `https://intake.fra2.sekoia.io/api/v1/intake-http/<path>` |
+| MCO1 | `https://intake.mco1.sekoia.io/api/v1/intake-http/<path>` |
+| UAE1 | `https://intake.uae1.sekoia.io/api/v1/intake-http/<path>` |
+| USA1 | `https://intake.usa1.sekoia.io/api/v1/intake-http/<path>` |
+| SGP1 | `https://intake.sgp1.sekoia.io/api/v1/intake-http/<path>` |
 
 To derive other ingestion paths `/<path>` from this page, use:
 
 - FRA1 base URL: `https://intake.sekoia.io`
-- Other regions base URL: `https://intake.<region>.io/api/v1/intake-http`
+- Other regions base URL: `https://intake.<region>.sekoia.io/api/v1/intake-http`
 
 Then append the path `/<path>` (examples: `/plain`, `/plain/batch`, `/jsons`, `/batch`, `/array`, etc.) to the corresponding regional base URL.
 
 Examples:
 - `https://intake.sekoia.io/batch`
-- `https://intake.fra2.io/api/v1/intake-http/batch`
-- `https://intake.mc01.io/api/v1/intake-http/jsons`
-- `https://intake.uae1.io/api/v1/intake-http/plain/batch`
+- `https://intake.fra2.sekoia.io/api/v1/intake-http/batch`
+- `https://intake.mco1.sekoia.io/api/v1/intake-http/jsons`
+- `https://intake.uae1.sekoia.io/api/v1/intake-http/plain/batch`
 
 !!! warning
     The examples below use FRA1 URLs for readability. For other regions, replace the base URL with your regional endpoint.


### PR DESCRIPTION
## Description

- Fixes https://github.com/SekoiaLab/integration/issues/1595
- Fixes https://github.com/SekoiaLab/integration/issues/1596

## Changelog

### Added

- Include information and examples for all supported regions (FRA1, FRA2, MCO1, UAE1, USA1, SGP1)
- Clarify URL scheme differences: FRA1 legacy vs API-prefixed scheme for other regions
- Label existing examples as FRA1-specific and warn users to adapt code samples for other regions

### Fixed

- Correct field name typo: `intakey_key` → `intake_key` in structured content section
- Improve wording: "query string" (was "querystring"), "Sekoia.io's" capitalization