### PR TITLE
docs(sol): add null property checking documentation

### DIFF
--- a/docs/xdr/features/investigate/sol_how_to_guides.md
+++ b/docs/xdr/features/investigate/sol_how_to_guides.md
@@ -343,29 +343,7 @@ You can combine null checks with other conditions in the same `where` clause:
     | 2026-03-26T15:35:14.738Z | ada_lovelace | www.example.com |
     | 2026-03-26T15:30:02.110Z | grace_hopper | www.test.org    |
 
-### Provide a fallback value instead of filtering
-
-If you want to keep rows with a missing field but display a default value, use `coalesce()` instead of filtering:
-
-=== "Query"
-
-    ```shell
-    events
-    | where timestamp > ago(24h)
-    | aggregate count() by user_identifier = coalesce(user.name, user.email, "Unknown")
-    | order by count desc
-    | limit 100
-    ```
-
-=== "Results"
-
-    | user_identifier | count |
-    | --------------- | ----- |
-    | ada_lovelace    | 152   |
-    | ken@example.com | 42    |
-    | Unknown         | 18    |
-
-For the full reference, see [Where](sol_ref_operators.md#where) and [Null handling: coalesce()](sol_ref_functions.md#null-handling-coalesce).
+For the full reference, see [Where](sol_ref_operators.md#where).
 
 
 ## How to build a query library

--- a/docs/xdr/features/investigate/sol_how_to_guides.md
+++ b/docs/xdr/features/investigate/sol_how_to_guides.md
@@ -275,6 +275,99 @@ SOL Datasets allow you to import CSV files and use them in your queries. This is
 For the full guide on importing CSVs, multi-tenancy rules, and advanced query patterns, see the dedicated [SOL Datasets](sol_datasets.md) page.
 
 
+## How to check for non-null properties
+
+Many event fields are optional and may be absent from some records. Use `!= null` to keep only rows where a field is present, or `== null` to find rows where a field is missing.
+
+### Filter out rows with a missing field
+
+=== "Query"
+
+    ```shell
+    events
+    | where timestamp > ago(24h) and user.name != null
+    | select timestamp, host.name, user.name
+    | order by timestamp desc
+    | limit 100
+    ```
+
+=== "Results"
+
+    | timestamp                | host.name    | user.name    |
+    | ------------------------ | ------------ | ------------ |
+    | 2026-03-26T15:35:14.738Z | laptop-chris | ada_lovelace |
+    | 2026-03-26T15:30:02.110Z | laptop-chris | grace_hopper |
+
+### Find rows where a field is absent
+
+Checking for `== null` is useful to detect incomplete or unparsed events:
+
+=== "Query"
+
+    ```shell
+    events
+    | where timestamp > ago(24h) and process.name != null and process.command_line == null
+    | select timestamp, host.name, process.name
+    | order by timestamp desc
+    | limit 100
+    ```
+
+=== "Results"
+
+    | timestamp                | host.name       | process.name |
+    | ------------------------ | --------------- | ------------ |
+    | 2026-03-26T14:20:15.441Z | laptop-6a1ec62f | svchost.exe  |
+    | 2026-03-26T14:17:31.554Z | laptop-b3205bc2 | lsass.exe    |
+
+### Combine multiple null checks
+
+You can combine null checks with other conditions in the same `where` clause:
+
+=== "Query"
+
+    ```shell
+    events
+    | where timestamp >= ago(24h)
+          and event.action == 'blocked'
+          and user.name != null
+          and url.domain != null
+    | select timestamp, user.name, url.domain
+    | order by timestamp desc
+    | limit 100
+    ```
+
+=== "Results"
+
+    | timestamp                | user.name    | url.domain      |
+    | ------------------------ | ------------ | --------------- |
+    | 2026-03-26T15:35:14.738Z | ada_lovelace | www.example.com |
+    | 2026-03-26T15:30:02.110Z | grace_hopper | www.test.org    |
+
+### Provide a fallback value instead of filtering
+
+If you want to keep rows with a missing field but display a default value, use `coalesce()` instead of filtering:
+
+=== "Query"
+
+    ```shell
+    events
+    | where timestamp > ago(24h)
+    | aggregate count() by user_identifier = coalesce(user.name, user.email, "Unknown")
+    | order by count desc
+    | limit 100
+    ```
+
+=== "Results"
+
+    | user_identifier | count |
+    | --------------- | ----- |
+    | ada_lovelace    | 152   |
+    | ken@example.com | 42    |
+    | Unknown         | 18    |
+
+For the full reference, see [Where](sol_ref_operators.md#where) and [Null handling: coalesce()](sol_ref_functions.md#null-handling-coalesce).
+
+
 ## How to build a query library
 
 Build a collection of reusable queries to accelerate your team's investigations:

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -202,10 +202,6 @@ Many event fields are optional and may not be present in every event. Use `!= nu
         | 2026-03-26T14:20:15.441Z | laptop-6a1ec62f | svchost.exe  |
         | 2026-03-26T14:17:31.554Z | laptop-b3205bc2 | lsass.exe    |
 
-!!! tip
-
-    To provide a fallback value for null fields instead of filtering them out, use the [`coalesce()`](sol_ref_functions.md#null-handling-coalesce) function.
-
 ## Nested query
 
 Use the `in` operator to use the results of a previous query.

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -160,6 +160,52 @@ Use the `where` operator to filter rows by a list of conditions. Use parenthesis
         | 2026-03-26T14:20:15.441Z | Android                |
         | 2026-03-26T14:19:47.883Z | Mac                    |
 
+### Checking for non-null properties
+
+Many event fields are optional and may not be present in every event. Use `!= null` to keep only rows where a field has a value, or `== null` to find rows where the field is absent.
+
+!!! example "Retrieve events where `user.name` is present"
+
+    === "Query"
+
+        ``` shell
+        events
+        | where timestamp > ago(24h) and user.name != null
+        | select timestamp, host.name, user.name
+        | limit 100
+
+        ```
+
+    === "Results"
+
+        | timestamp                | host.name    | user.name      |
+        | ------------------------ | ------------ | -------------- |
+        | 2026-03-26T14:22:03.120Z | laptop-chris | ada_lovelace   |
+        | 2026-03-26T14:19:47.883Z | laptop-chris | grace_hopper   |
+
+!!! example "Find events where `process.command_line` is missing"
+
+    === "Query"
+
+        ``` shell
+        events
+        | where timestamp > ago(24h) and process.name != null and process.command_line == null
+        | select timestamp, host.name, process.name
+        | limit 100
+
+        ```
+
+    === "Results"
+
+        | timestamp                | host.name       | process.name |
+        | ------------------------ | --------------- | ------------ |
+        | 2026-03-26T14:20:15.441Z | laptop-6a1ec62f | svchost.exe  |
+        | 2026-03-26T14:17:31.554Z | laptop-b3205bc2 | lsass.exe    |
+
+!!! tip
+
+    To provide a fallback value for null fields instead of filtering them out, use the [`coalesce()`](sol_ref_functions.md#null-handling-coalesce) function.
+
 ## Nested query
 
 Use the `in` operator to use the results of a previous query.


### PR DESCRIPTION
- Add 'Checking for non-null properties' subsection to the Where operator reference, covering != null, == null, and a coalesce() tip
- Add 'How to check for non-null properties' how-to guide section with four practical examples: filter missing fields, find absent fields, combine multiple null checks, and use coalesce() as a fallback