### PR TITLE
docs: add Sankey chart to visualization guide and SOL render reference

### DIFF
--- a/docs/xdr/features/investigate/data_visualization_guide.md
+++ b/docs/xdr/features/investigate/data_visualization_guide.md
@@ -2,7 +2,7 @@
 
 The Query Builder offers various options for displaying your results depending on your analytical needs. These visualizations help you transform raw data into actionable insights for reporting and threat hunting.
 
-The query builder offers six visualization options, grouped into two categories:
+The query builder offers seven visualization options, grouped into two categories:
 
 1. **Total values**: Focuses on comparing values across different categories at a specific point in time.
 2. **Time series**: Highlights how data evolves over time, enabling the analysis of trends and changes.
@@ -48,6 +48,26 @@ To ensure a clear display, the maximum number of values allowed is limited to 80
 * In the **Y-axis**, select the column representing numeric values (numeric data only).
 
  ![bar chart](/assets/operation_center/events/qb-bar-chart.png){: style="max-width:100%"}
+
+### Sankey Chart
+The Sankey Chart visualizes flows between entities, making it ideal for mapping relationships such as network traffic, user activity paths, or any directional data between two sets of values.
+
+**Configuration**:
+
+* In the **Source** field, select the column representing the origin of the flow (e.g., source IP, user, process).
+* In the **Target** field, select the column representing the destination of the flow (e.g., destination IP, asset, URL).
+* In the **Value** field, optionally select a numeric column representing the flow magnitude (e.g., count, bytes). If omitted, each row is counted as 1.
+
+!!! tip "SOL syntax"
+
+    Use `render sankey with (source=<column>, target=<column>, value=<column>)` to generate a Sankey chart directly from a SOL query.
+
+    ```
+    events
+    | where timestamp > ago(1h)
+    | aggregate count() by source.ip, destination.ip
+    | render sankey with (source=source.ip, target=destination.ip, value=count())
+    ```
 
 ## Time series visualizations
 

--- a/docs/xdr/features/investigate/data_visualization_guide.md
+++ b/docs/xdr/features/investigate/data_visualization_guide.md
@@ -67,7 +67,7 @@ The Sankey Chart visualizes flows between entities, making it ideal for mapping 
     | where timestamp > ago(1h)
     | aggregate count() by source.ip, destination.ip
     | limit 50
-    | render sankey with (source=source.ip, target=destination.ip, value=count())
+    | render sankey with (source=source.ip, target=destination.ip, value=count)
     ```
 
 ## Time series visualizations

--- a/docs/xdr/features/investigate/data_visualization_guide.md
+++ b/docs/xdr/features/investigate/data_visualization_guide.md
@@ -66,6 +66,7 @@ The Sankey Chart visualizes flows between entities, making it ideal for mapping 
     events
     | where timestamp > ago(1h)
     | aggregate count() by source.ip, destination.ip
+    | limit 50
     | render sankey with (source=source.ip, target=destination.ip, value=count())
     ```
 

--- a/docs/xdr/features/investigate/notebooks.md
+++ b/docs/xdr/features/investigate/notebooks.md
@@ -119,7 +119,7 @@ The `default` notebook template will be suggested for use in cases and alerts, e
 
 ### Query Builder Editor
 * Display data in tables
-* Create various data visualizations, including pie charts, line charts, bar charts, column charts, and numeric displays
+* Create various data visualizations, including pie charts, line charts, bar charts, column charts, Sankey charts, and numeric displays
 
 ![notebook_viz](/assets/operation_center/notebook_viz.png){: style="max-width:100%"}
 

--- a/docs/xdr/features/investigate/sol_how_to_guides.md
+++ b/docs/xdr/features/investigate/sol_how_to_guides.md
@@ -203,6 +203,7 @@ Use the `render` operator to display query results as charts. Supported chart ty
 - `columnchart` — Vertical bar chart
 - `barchart` — Horizontal bar chart
 - `linechart` — Line chart
+- `sankey` — Flow chart
 
 ### Basic chart
 

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -648,6 +648,7 @@ For the `sankey` chart, the syntax uses `source`, `target`, and `value` paramete
         events
         | where timestamp > ago(1h)
         | aggregate count() by source.ip, destination.ip
+        | limit 50
         | render sankey with (source=source.ip, target=destination.ip, value=count())
 
         ```

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -601,11 +601,21 @@ Use the `render` operator to display results in a chart to identify more easily 
 - `columnchart`
 - `barchart`
 - `linechart`
+- `sankey`
 
 ``` shell
 <table name>
 | aggregate <function> by <column name>
 | render <chart_type> with (x=<column name>, y=<column name>, breakdown_by=<column name>, mode=<grouped | stacked>)
+
+```
+
+For the `sankey` chart, the syntax uses `source`, `target`, and `value` parameters instead:
+
+``` shell
+<table name>
+| aggregate <function> by <source column>, <target column>
+| render sankey with (source=<source column>, target=<target column>, value=<value column>)
 
 ```
 
@@ -629,6 +639,22 @@ Use the `render` operator to display results in a chart to identify more easily 
         | laptop-6a1ec62f         | 16    |
         | laptop-chris            | 525   |
         | laptop-b3205bc2         | 517   |
+
+!!! example "Visualize network flows between source and destination IPs as a Sankey chart"
+
+    === "Query"
+
+        ``` shell
+        events
+        | where timestamp > ago(1h)
+        | aggregate count() by source.ip, destination.ip
+        | render sankey with (source=source.ip, target=destination.ip, value=count())
+
+        ```
+
+    === "Results"
+
+        A Sankey chart showing the volume of connections from each source IP to each destination IP.
 
 ## Join tables
 

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -649,7 +649,7 @@ For the `sankey` chart, the syntax uses `source`, `target`, and `value` paramete
         | where timestamp > ago(1h)
         | aggregate count() by source.ip, destination.ip
         | limit 50
-        | render sankey with (source=source.ip, target=destination.ip, value=count())
+        | render sankey with (source=source.ip, target=destination.ip, value=count)
 
         ```
 


### PR DESCRIPTION
## Summary

Adds documentation for the new **Sankey chart** visualization type available in the Query Builder and notebooks.

## Changes

### `data_visualization_guide.md`
- Updated chart count from 6 → 7 visualization options
- Added **Sankey Chart** section under *Total values* with:
  - Description (flow visualization between entities)
  - Source/Target/Value field configuration
  - SOL tip with example query

### `sol_ref_operators.md`
- Added `sankey` to the list of supported render chart types
- Added dedicated syntax block for sankey's `source=`, `target=`, `value=` parameters (distinct from the standard `x=`, `y=` params)
- Added example query with Sankey output description

### `notebooks.md`
- Added Sankey to the list of supported chart types in the Query Builder Editor section