### PR TITLE
docs(darktrace): clarify connector not needed for On-Premise version

### DIFF
--- a/docs/integration/categories/network_security/darktrace_threat_visualizer.md
+++ b/docs/integration/categories/network_security/darktrace_threat_visualizer.md
@@ -49,14 +49,14 @@ This setup guide describes how to forward logs from Darktrace Threat visualizer 
 
 {!_shared_content/integration/intake_configuration.md!}
 
-#### For Cloud version only
-
-{!_shared_content/integration/connector_configuration.md!}
-
 !!! warning "On-Premise version — connector not required"
     For the **On-Premise** version, a connector is **not** needed. Logs are forwarded via a self-managed syslog forwarder (see below).
 
     However, due to how the intake format is currently integrated, the Sekoia interface may still prompt you to fill in connector information even when creating an On-Premise intake. As a workaround, **enter placeholder (fake) data** in the connector fields and **disable the connector** afterwards.
+
+#### For Cloud version only
+
+{!_shared_content/integration/connector_configuration.md!}
 
 ### Instructions on the 3rd party solution
 #### For Cloud version - Acquire your public and private key

--- a/docs/integration/categories/network_security/darktrace_threat_visualizer.md
+++ b/docs/integration/categories/network_security/darktrace_threat_visualizer.md
@@ -53,6 +53,11 @@ This setup guide describes how to forward logs from Darktrace Threat visualizer 
 
 {!_shared_content/integration/connector_configuration.md!}
 
+!!! warning "On-Premise version — connector not required"
+    For the **On-Premise** version, a connector is **not** needed. Logs are forwarded via a self-managed syslog forwarder (see below).
+
+    However, due to how the intake format is currently integrated, the Sekoia interface may still prompt you to fill in connector information even when creating an On-Premise intake. As a workaround, **enter placeholder (fake) data** in the connector fields and **disable the connector** afterwards.
+
 ### Instructions on the 3rd party solution
 #### For Cloud version - Acquire your public and private key
 


### PR DESCRIPTION
## Summary

For the On-Premise version of Darktrace, a connector is not required — only the Cloud version needs one.

However, due to how the intake format is integrated, the Sekoia UI currently prompts for connector information even when creating an On-Premise intake. This PR adds a warning admonition to inform users of this limitation and provides the workaround: enter placeholder data and disable the connector.

## Changes

- Added a `warning` admonition in the Darktrace Threat Visualizer integration doc, placed before the connector configuration section so On-Premise users see it before encountering the connector prompts.