### PR TITLE
HarfangLab Software Assets in the Asset Categories section doc

### DIFF
--- a/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
+++ b/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
@@ -1,0 +1,146 @@
+## OCSF Mapping for HarfangLab Software Assets
+
+
+**OCSF Class:** `Software Inventory Info`
+
+
+
+**Class UID:** `5020`
+
+
+
+**OCSF Version:** `1.5.0`
+
+
+## Information Collected
+
+The HarfangLab Software Assets connector fetches comprehensive information and transforms it into the OCSF (Open Cybersecurity Schema Framework) format for standardized security monitoring and asset management.
+
+
+### API Response Examples
+
+#### HarfangLab Software Inventory Sample
+Agent data sample for harfanglab api response (used to build the device context).
+
+```json
+{
+  "id": "3891597d-8696-4fc4-a260-b04880bdbd68",
+  "hostname": "testhostaname1",
+  "firstseen": "2025-06-11T00:15:06.454734Z",
+  "lastseen": "2025-06-11T00:27:06.693963Z",
+  "ostype": "windows",
+  "osproducttype": "Windows 11 Enterprise Evaluation",
+  "ipaddress": "1.2.2.5",
+  "domainname": "TestGROUP"
+}
+```
+
+#### HarfangLab Application Sample
+Application data sample from GET /api/data/endpoint/Agent/&lt;agent_uid&gt;/applications/.
+
+```json
+{
+  "id": "0e8412d1-f81f-4739-b254-2879bb7bc5e5",
+  "active": true,
+  "installation_date": null,
+  "first_seen": "2026-03-27T10:05:27.558496Z",
+  "last_seen": "2026-03-27T10:06:59.416022Z",
+  "first_version": "0.19051.7-0",
+  "last_version": "0.19051.7-0",
+  "installation_count": 1,
+  "name": "YourPhone",
+  "publisher": "Microsoft Corporation",
+  "ostype": "windows",
+  "cpe_prefix": null,
+  "app_type": "uwp",
+  "description": null
+}
+```
+
+
+### Data Mapping Table
+
+The following table shows how source data is mapped to OCSF model fields:
+
+| Source Field | OCSF Field Path | Description | Data Type | Logic |
+|--------------|-----------------|-------------|-----------|-------|
+| `static: 2` | `activity_id` | OCSF activity ID | `integer` | Always 2 for 'Collect' activity |
+| `static: Collect` | `activity_name` | OCSF activity name | `string` | Always 'Collect' for asset inventory |
+| `static: Discovery` | `category_name` | OCSF category name | `string` | Always 'Discovery' |
+| `static: 5` | `category_uid` | OCSF category UID | `integer` | Always 5 for Discovery category |
+| `static: Software Inventory Info` | `class_name` | OCSF class name | `string` | Always 'Software Inventory Info' |
+| `static: 5020` | `class_uid` | OCSF class UID | `integer` | Always 5020 for Software Inventory Info |
+| `static: 502002` | `type_uid` | OCSF type UID | `integer` | Always 502002 for Software Inventory Info: Collect |
+| `static: Software Inventory Info: Collect` | `type_name` | OCSF type name | `string` | Always 'Software Inventory Info: Collect' for this event type |
+| `agent.firstseen` | `time` | OCSF event timestamp | `timestamp` | Convert ISO 8601 to Unix epoch from the parent agent; use for OCSF event timestamp |
+| `static: Harfanglab EDR` | `metadata.product.name` | Source product name | `string` | Always 'Harfanglab EDR' |
+| `static: 24.12` | `metadata.product.version` | Product version | `string` | Fixed HarfangLab product version |
+| `static: 1.5.0` | `metadata.version` | OCSF schema version | `string` | Fixed OCSF schema version |
+| `static: 2` | `device.type_id` | Device type ID | `integer` | Direct mapping of type to desktop type ID |
+| `static: Desktop` | `device.type` | OCSF device type | `string` | Direct mapping of type to desktop type |
+| `agent.id` | `device.uid` | Device unique identifier | `string` | Direct mapping of HarfangLab agent unique ID |
+| `agent.osproducttype` | `device.os.name` | Operating system name and version | `string` | Direct mapping of OS product type (e.g., 'Windows 10 Professional', 'Ubuntu 20.04') |
+| `agent.ostype` | `device.os.type` | Operating system type | `string` | Normalize ostype to OCSF OSTypeStr: WINDOWS→'Windows', LINUX→'Linux', MACOS→'macOS', OTHER→'Other', UNKNOWN→'Unknown' |
+| `agent.ostype` | `device.os.type_id` | OCSF operating system type ID | `integer` | Map ostype to OCSF OSTypeId: WINDOWS→100, LINUX→200, MACOS→300, OTHER→99, UNKNOWN→0 |
+| `agent.hostname` | `device.hostname` | Device hostname | `string` | Direct mapping of hostname |
+| `agent.domainname` | `device.domain` | Device domain or realm | `string` | Direct mapping of domain name |
+| `agent.ipaddress` | `device.ip` | Device IP address | `string` | Direct mapping of IP address |
+| `agent.firstseen` | `device.first_seen_time` | Device first seen timestamp | `timestamp` | Convert ISO 8601 to Unix epoch |
+| `agent.lastseen` | `device.last_seen_time` | Device last seen timestamp | `timestamp` | Convert ISO 8601 to Unix epoch |
+| `application.name` | `sbom.package.name` | Software package name | `string` | Direct mapping of application name |
+| `application.last_version \|\| application.first_version \|\| 'unknown'` | `sbom.package.version` | Software package version | `string` | Use last_version if available, fallback to first_version, then 'unknown' |
+| `application.id` | `sbom.package.uid` | Software package unique identifier | `string` | Direct mapping of application unique ID |
+| `application.cpe_prefix` | `sbom.package.cpe_name` | Common Platform Enumeration name | `string` | Direct mapping of CPE prefix if available; null otherwise |
+| `application.app_type` | `sbom.package.type` | Software package type | `string` | Map app_type to OCSF PackageTypeStr: uwp/win32/macos/linux→'Application', os→'Operating System', unknown→'Unknown' |
+| `application.app_type` | `sbom.package.type_id` | OCSF software package type ID | `integer` | Map app_type to OCSF PackageTypeId: uwp/win32/macos/linux→1 (APPLICATION), os→2 (OPERATINGSYSTEM), unknown→0 (UNKNOWN) |
+
+
+### OCSF Model Structure
+
+#### Software Inventory Info: Collect
+Transformed HarfangLab api response to OCSF Software Inventory Info event
+
+```json
+{
+  "activity_id": 2,
+  "activity_name": "Collect",
+  "category_name": "Discovery",
+  "category_uid": 5,
+  "class_name": "Software Inventory Info",
+  "class_uid": 5020,
+  "type_name": "Software Inventory Info: Collect",
+  "type_uid": 502002,
+  "time": 1749316506,
+  "metadata": {
+    "product": {
+      "name": "HarfangLab EDR",
+      "version": "24.12"
+    },
+    "version": "1.5.0"
+  },
+  "device": {
+    "uid": "3891597d-8696-4fc4-a260-b04880bdbd68",
+    "hostname": "testhostaname1",
+    "type": "Desktop",
+    "type_id": 2,
+    "ip": "1.2.2.5",
+    "domain": "TestGROUP",
+    "first_seen_time": 1749316506,
+    "last_seen_time": 1749317226,
+    "os": {
+      "name": "Windows 11 Enterprise Evaluation",
+      "type": "windows",
+      "type_id": 100
+    }
+  },
+  "sbom": {
+    "package": {
+      "name": "YourPhone",
+      "version": "0.19051.7-0",
+      "uid": "0e8412d1-f81f-4739-b254-2879bb7bc5e5",
+      "type": "Application",
+      "type_id": 1
+    }
+  }
+}
+```

--- a/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
+++ b/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
@@ -20,7 +20,7 @@ The HarfangLab Software Assets connector fetches comprehensive information and t
 ### API Response Examples
 
 #### HarfangLab Software Inventory Sample
-Agent data sample for harfanglab api response (used to build the device context).
+Agent data sample from the HarfangLab API response (used to build the device context).
 
 ```json
 {

--- a/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
+++ b/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
@@ -98,7 +98,7 @@ The following table shows how source data is mapped to OCSF model fields:
 ### OCSF Model Structure
 
 #### Software Inventory Info: Collect
-Transformed HarfangLab api response to OCSF Software Inventory Info event
+Transformed HarfangLab API response to an OCSF Software Inventory Info event
 
 ```json
 {

--- a/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
+++ b/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
@@ -73,7 +73,7 @@ The following table shows how source data is mapped to OCSF model fields:
 | `static: 502002` | `type_uid` | OCSF type UID | `integer` | Always 502002 for Software Inventory Info: Collect |
 | `static: Software Inventory Info: Collect` | `type_name` | OCSF type name | `string` | Always 'Software Inventory Info: Collect' for this event type |
 | `agent.firstseen` | `time` | OCSF event timestamp | `timestamp` | Convert ISO 8601 to Unix epoch from the parent agent; use for OCSF event timestamp |
-| `static: Harfanglab EDR` | `metadata.product.name` | Source product name | `string` | Always 'Harfanglab EDR' |
+| `static: HarfangLab EDR` | `metadata.product.name` | Source product name | `string` | Always 'HarfangLab EDR' |
 | `static: 24.12` | `metadata.product.version` | Product version | `string` | Fixed HarfangLab product version |
 | `static: 1.5.0` | `metadata.version` | OCSF schema version | `string` | Fixed OCSF schema version |
 | `static: 2` | `device.type_id` | Device type ID | `integer` | Direct mapping of type to desktop type ID |

--- a/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
+++ b/_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md
@@ -9,7 +9,7 @@
 
 
 
-**OCSF Version:** `1.5.0`
+**OCSF Version:** `1.6.0`
 
 
 ## Information Collected

--- a/docs/integration/assets_categories/overview.md
+++ b/docs/integration/assets_categories/overview.md
@@ -12,6 +12,8 @@ The Asset Categories section is organized into several sub-categories, each repr
 
 - **Vulnerability**: Asset connectors for vulnerability management and exposure platforms. This includes:
 
+- **Software**: Asset connectors for software inventory management, providing visibility into applications installed across your endpoints. This includes:
+
 Each category contains detailed pages for individual asset connectors, including configuration steps, required permissions, and integration guides.
 
 ## What are Asset Connectors?

--- a/docs/integration/assets_categories/overview.md
+++ b/docs/integration/assets_categories/overview.md
@@ -1,18 +1,18 @@
 # Asset Categories Overview
 
-Welcome to the Asset Categories section of our documentation! This section is designed to help you find and utilize various asset connectors that bring your IT infrastructure visibility directly into the Sekoia.io SOC Platform. Whether you're looking to manage devices, users, or vulnerabilities, you'll find the resources and guidance you need here, categorized by the type of asset they represent.
+Welcome to the Asset Categories section of our documentation! This section is designed to help you find and utilize various asset connectors that bring your IT infrastructure visibility directly into the Sekoia.io SOC Platform. Whether you're looking to manage devices, users, vulnerabilities, or software inventory, you'll find the resources and guidance you need here, categorized by the type of asset they represent.
 
 ## Structure of the Asset Categories Section
 
 The Asset Categories section is organized into several sub-categories, each representing a different type of asset. Below is the structure of the folder:
 
-- **Device**: Asset connectors for endpoint devices, workstations, and compute instances across different platforms. This includes:
+- **Device**: Asset connectors for endpoint devices, workstations, and compute instances across different platforms.
 
-- **User**: Asset connectors for identity and access management systems. This includes:
+- **User**: Asset connectors for identity and access management systems.
 
-- **Vulnerability**: Asset connectors for vulnerability management and exposure platforms. This includes:
+- **Vulnerability**: Asset connectors for vulnerability management and exposure platforms.
 
-- **Software**: Asset connectors for software inventory management, providing visibility into applications installed across your endpoints. This includes:
+- **Software**: Asset connectors for software inventory management, providing visibility into applications installed across your endpoints.
 
 Each category contains detailed pages for individual asset connectors, including configuration steps, required permissions, and integration guides.
 

--- a/docs/integration/assets_categories/software/harfanglab_software.md
+++ b/docs/integration/assets_categories/software/harfanglab_software.md
@@ -1,0 +1,62 @@
+uuid: 3e5f8c2a-7d4b-4e6f-a891-c0d2e3f4a5b6
+name: HarfangLab Software Assets
+type: asset
+
+## Overview
+
+HarfangLab EDR is a European EDR for Windows, macOS, and Linux that delivers real-time telemetry, ATT&CK-mapped detections, and rapid response (host isolation, process kill, quarantine). This setup guide shows how to forward software assets — the list of applications installed on endpoints monitored by HarfangLab EDR — to Sekoia.io.
+
+- **Vendor**: HarfangLab
+- **Product**: HarfangLab EDR
+- **Supported environment**: SaaS
+
+## Configure
+
+### How to create an API token
+
+To connect HarfangLab to Sekoia.io, you need to create an API key in your HarfangLab console. Follow these steps:
+
+1. Click on **Users** under administration panel.
+
+    ![Account page showing navigation to API Keys tab in HarfangLab](/assets/operation_center/asset_connectors/device/harfanglab/users_button.png)
+
+2. Click on the user you want.
+
+3. Click **Generate token** to generate API token.
+
+    ![Generate API Keys button highlighted for clarity](/assets/operation_center/asset_connectors/device/harfanglab/generate_button.png)
+
+4. Copy the API key to a safe place and start using it in Sekoia.io.
+
+!!! warning
+    - Ensure the user account exists before generating an API token.
+    - The API token is displayed only once at creation. Save it securely; if you lose it, you must generate a new one.
+    - When copying the API key, ensure you copy only the raw key value (excluding any `token_` prefix if displayed).
+
+
+### Create your asset
+
+To start getting your HarfangLab software assets into Sekoia.io, you need to create an asset connector on the [Assets page](https://app.sekoia.io/assets). To do so, follow these steps:
+
+1. Click the **Asset connectors** button to create a new connector.
+
+    ![Asset connectors button highlighted](/assets/operation_center/asset_connectors/vulnerability/common/create_asset_connector_button.png)
+
+2. Click the **+ New connector** button.
+    
+    ![create_asset_step_2.png](/assets/operation_center/asset_connectors/vulnerability/common/create_asset_connector_1.png)
+
+3. Choose **HarfangLab Software Assets**, give it a name, and fill the required fields:
+
+    - **Name**: A descriptive name for this connector.
+    - **URL**: The URL of your HarfangLab instance (including port if applicable, e.g. `https://your-harfanglab-instance.com:8443`).
+    - **API Token**: The API token generated in the previous step.
+
+4. Test the connection by clicking the **Test connector** button.
+
+5. Click the **Create asset connector** button.
+
+!!! warning
+    - Make sure to include your port number in the `URL` field by appending it to the URL, for example: `https://your-harfanglab-instance.com:8443`.
+
+{!_shared_content/operations_center/integrations/generated_assets_documentation/harfanglab_software.md!}

--- a/docs/integration/assets_categories/software/harfanglab_software.md
+++ b/docs/integration/assets_categories/software/harfanglab_software.md
@@ -2,6 +2,8 @@ uuid: 3e5f8c2a-7d4b-4e6f-a891-c0d2e3f4a5b6
 name: HarfangLab Software Assets
 type: asset
 
+_**[Reveal module](/xdr/features/modules/reveal_index.md)**  — This feature requires the Reveal add-on module._
+
 ## Overview
 
 HarfangLab EDR is a European EDR for Windows, macOS, and Linux that delivers real-time telemetry, ATT&CK-mapped detections, and rapid response (host isolation, process kill, quarantine). This setup guide shows how to forward software assets — the list of applications installed on endpoints monitored by HarfangLab EDR — to Sekoia.io.
@@ -9,6 +11,9 @@ HarfangLab EDR is a European EDR for Windows, macOS, and Linux that delivers rea
 - **Vendor**: HarfangLab
 - **Product**: HarfangLab EDR
 - **Supported environment**: SaaS
+
+!!! note
+    This asset connector is currently in beta. Enable the `reveal-beta-connectors` feature flag to display it.
 
 ## Configure
 

--- a/docs/integration/assets_categories/software/harfanglab_software.md
+++ b/docs/integration/assets_categories/software/harfanglab_software.md
@@ -14,7 +14,7 @@ HarfangLab EDR is a European EDR for Windows, macOS, and Linux that delivers rea
 
 ### How to create an API token
 
-To connect HarfangLab to Sekoia.io, you need to create an API key in your HarfangLab console. Follow these steps:
+To connect HarfangLab to Sekoia.io, you need to generate an API token in your HarfangLab console. Follow these steps:
 
 1. Click on **Users** under administration panel.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -596,6 +596,8 @@ nav:
       - Okta: integration/assets_categories/device/okta_device.md
       - SentinelOne EDR: integration/assets_categories/device/sentinelone_edr.md
       - Sophos EDR: integration/assets_categories/device/sophos_edr.md
+    - Software:
+      - HarfangLab Software Assets: integration/assets_categories/software/harfanglab_software.md
     - User:
       - AWS IAM: integration/assets_categories/user/aws_iam_user.md
       - Microsoft Active Directory: integration/assets_categories/user/microsoft_ad_user.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -597,7 +597,7 @@ nav:
       - SentinelOne EDR: integration/assets_categories/device/sentinelone_edr.md
       - Sophos EDR: integration/assets_categories/device/sophos_edr.md
     - Software:
-      - HarfangLab Software Assets: integration/assets_categories/software/harfanglab_software.md
+      - HarfangLab EDR: integration/assets_categories/software/harfanglab_software.md
     - User:
       - AWS IAM: integration/assets_categories/user/aws_iam_user.md
       - Microsoft Active Directory: integration/assets_categories/user/microsoft_ad_user.md


### PR DESCRIPTION
## Description

- Introduce support documentation for HarfangLab Software Assets in the Asset Categories section
- Add a new Software category entry in navigation
- Update the Asset Categories overview to describe software inventory connectors
- Create a dedicated HarfangLab Software Assets page with setup instructions (API token creation and connector configuration)
- Include the shared generated mapping content covering OCSF Software Inventory Info fields and sample transformed event data