### PR TITLE
docs: improve Ignore Useless Event (action=8) documentation

### DIFF
--- a/docs/xdr/features/collect/create_optimization_rule.md
+++ b/docs/xdr/features/collect/create_optimization_rule.md
@@ -41,7 +41,7 @@ To create a new optimization rule, send a POST request to the configuration endp
     This command ignores NetFlow events based on parsed fields (for example, specific ports or datasets).
     ```bash
     curl --request POST \
-    --url [https://api.sekoia.io/v1/sic/conf/intakes/optimization_rules](https://api.sekoia.io/v1/sic/conf/intakes/optimization_rules) \
+    --url https://api.sekoia.io/v1/sic/conf/intakes/optimization_rules \
     --header 'Authorization: Bearer YOUR_TOKEN' \
     --header 'Content-Type: application/json' \
     --data '{
@@ -52,6 +52,21 @@ To create a new optimization rule, send a POST request to the configuration endp
         { "field": "event.dataset", "operator": "==", "value": "netflow" },
         { "field": "destination.port", "operator": "==", "value": 389 }
       ]
+    }'
+    ```
+
+??? example "Example: Ignore unparsed events on a specific intake"
+    Use action `8` (Ignore Useless Event) to silently drop events that your parser could not extract any data from.
+    No filters are needed — the rule relies on the parser's internal detection of empty results.
+    ```bash
+    curl --request POST \
+    --url https://api.sekoia.io/v1/sic/conf/intakes/optimization_rules \
+    --header 'Authorization: Bearer YOUR_TOKEN' \
+    --header 'Content-Type: application/json' \
+    --data '{
+      "action": 8,
+      "description": "Ignore events with no parsed data",
+      "intake_uuid": "YOUR_INTAKE_UUID"
     }'
     ```
 

--- a/docs/xdr/features/collect/optimization_rules_reference.md
+++ b/docs/xdr/features/collect/optimization_rules_reference.md
@@ -37,12 +37,15 @@ When defining the "value" in a filter, you must match the data type of the field
 | **1** | **Ignore Event** |  Prevents the event from being analyzed or stored in the system. |
 | **2** | **Delete Message Field** |  Removes the message field from the event. |
 | **4** | **Shrink Event** |  Retains only the minimum required fields necessary for processing. |
-| **8** | **Ignore Useless Event** |  Discards the event if it contains no extractable data. |
+| **8** | **Ignore Useless Event** |  Discards the event if the parser extracted no fields from it. Unlike **Ignore Event** (action=1), this action is self-filtering: no filters are required, as it relies on the parser's own warning when nothing could be extracted. |
 | **16** | **Delete Non-Standard Fields** |  Deletes fields not included in official ECS or Sekoia Taxonomy. |
 
 !!! note "Visibility"
     Currently, only the **Ignore Event** (action=1) action will have a visible impact on the platform's usage page.
 
+!!! tip "When to use Ignore Useless Event (action=8)"
+    Use this action on intakes that receive noisy or malformed messages that your parser cannot extract any data from. Since the check is done internally by the parser, you do not need to define any filters — the rule can be applied with an empty filter list.
+
 ## See also
-* [Optimization rules overview](/xdr/features/collect/optimization_rules_overview.md) to understand how optimieation rules work.
+* [Optimization rules overview](/xdr/features/collect/optimization_rules_overview.md) to understand how optimization rules work.
 * [Create an optimization rule](/xdr/features/collect/create_optimization_rule.md) to start creating your rule thanks to our step by step guide. 


### PR DESCRIPTION
## Summary

Improves the documentation for the **Ignore Useless Event** optimization rule (action=8) based on a code review of the ingest service.

## Changes

### `optimization_rules_reference.md`
- Expanded action 8 description to clarify it is **self-filtering**: it relies on the parser's internal warning when no fields are extracted, so no filters are required
- Added a tip callout explaining when to use this action
- Fixed typo: `optimieation` → `optimization`

### `create_optimization_rule.md`
- Added a `curl` example for action 8 scoped to a specific intake (no filters needed)
- Fixed broken markdown link in the existing NetFlow curl example (the URL was wrapped in a markdown link syntax, making it invalid in a code block)