### PR TITLE
Clarify event size limit and rejection behavior

### DIFF
--- a/docs/xdr/FAQ/Log_collection_Troubleshoot.md
+++ b/docs/xdr/FAQ/Log_collection_Troubleshoot.md
@@ -62,7 +62,7 @@ The feedback you receive depends on the ingestion method:
 | Ingestion method | Rejection behavior |
 |---|---|
 | `intake.sekoia.io` (single event) | Returns an HTTP `413` error |
-| `intake.sekoia.io` (batch) | Returns a per-event ingestion status in the response body |
+| `intake.sekoia.io` (batch) | Returns a per-event ingestion status in the response body and an HTTP `413` error when all the events in the batch are rejected |
 | Syslog | Events are dropped silently, no feedback is returned |
 
 ### What to do when events are rejected

--- a/docs/xdr/FAQ/Log_collection_Troubleshoot.md
+++ b/docs/xdr/FAQ/Log_collection_Troubleshoot.md
@@ -48,7 +48,35 @@ Please consult our documentation for each technology used
 !!! note
    Please contact Support if you have any questions or feedbacks. We will be glad to assist you.
 
-### Truncating verification when in error
+## Event size limit and rejection behavior
 
-1. Check the size of the raw event, we truncate events larger than 250 KiB.
-2. If events are truncated of less than 250 KiB, we recommend to check each component on the collection chain and the source to identify where the event is truncated. 
+Events exceeding 250 KiB in size are rejected by Sekoia's ingestion pipeline. They are not truncated.
+
+!!! warning "Events larger than 250 KiB are rejected"
+    Sekoia drops any event that exceeds 250 KiB. These events are never ingested, parsed, or visible in the platform. Truncating oversized events is not possible, as it would produce malformed payloads (for example, broken JSON) that the parser cannot process.
+
+### How rejections are notified
+
+The feedback you receive depends on the ingestion method:
+
+| Ingestion method | Rejection behavior |
+|---|---|
+| `intake.sekoia.io` (single event) | Returns an HTTP `413` error |
+| `intake.sekoia.io` (batch) | Returns a per-event ingestion status in the response body |
+| Syslog | Events are dropped silently, no feedback is returned |
+
+### What to do when events are rejected
+
+**Identify oversized events**
+
+- For `intake.sekoia.io`, monitor your HTTP responses. A `413` error confirms that a single event exceeded the 250 KiB limit. For batches, inspect the per-event status returned in the response to identify which events were rejected.
+- For syslog ingestion, there is no built-in rejection signal. Check the size of raw events at the source or at each component of your collection chain before they reach Sekoia.
+
+**Reduce event size at the source**
+
+- Review your log source configuration and filter out unnecessary fields before forwarding events.
+- If your EDR or security tool generates very large events (for example, events containing full process memory dumps or large JSON payloads), configure it to reduce verbosity or split the data across multiple smaller events.
+- For structured formats such as JSON, ensure the payload is valid and does not include redundant or base64-encoded binary blobs.
+
+!!! tip "Test before deploying"
+    Before connecting a new log source, send a sample of raw events to a test intake and verify that none exceed 250 KiB. This prevents silent data loss in production.

--- a/docs/xdr/FAQ/Log_collection_Troubleshoot.md
+++ b/docs/xdr/FAQ/Log_collection_Troubleshoot.md
@@ -50,7 +50,7 @@ Please consult our documentation for each technology used
 
 ## Event size limit and rejection behavior
 
-Events exceeding 250 KiB in size are rejected by Sekoia's ingestion pipeline. They are not truncated.
+Events exceeding 250 KiB are rejected by Sekoia's ingestion pipeline.
 
 !!! warning "Events larger than 250 KiB are rejected"
     Sekoia drops any event that exceeds 250 KiB. These events are never ingested, parsed, or visible in the platform. Truncating oversized events is not possible, as it would produce malformed payloads (for example, broken JSON) that the parser cannot process.


### PR DESCRIPTION
Updated the FAQ section to clarify event size limits and rejection behavior, including details on how to identify oversized events and reduce their size at the source.

See support bug: https://github.com/orgs/SekoiaLab/projects/113/views/12?pane=issue&itemId=206157085&issue=SekoiaLab%7Cplatform%7C88657