### PR TITLE
Document cidr_match SOL function

### DIFF
--- a/docs/xdr/features/investigate/sol_best_practices.md
+++ b/docs/xdr/features/investigate/sol_best_practices.md
@@ -107,7 +107,7 @@ Use this table to identify which operations can be pushed down to the datasource
 | `\| aggregate <aggregations>` | When `<aggregations>` operate on simple field references. Only the first `aggregate` command can be pushed down |
 | `\| limit ...` | ✅ Always |
 | `\| top X by <definitions>` | When `<definitions>` are simple field references. For the `events` and `eternal_events` datasources, `top` cannot be pushed down after an aggregation |
-| `\| where <conditions>` | When `<conditions>` are simple comparison expressions over simple field references |
+| `\| where <conditions>` | When `<conditions>` are simple comparison expressions over simple field references, or a `cidr_match()` predicate over a supported IP field |
 | Constants and time functions (e.g. `now()`, `ago(24h)`) | ✅ Always |
 | Group-by time functions (`bin`, `year`, `month`, `week`) | ✅ Always |
 | `countif` aggregation function | ❌ Never |

--- a/docs/xdr/features/investigate/sol_best_practices.md
+++ b/docs/xdr/features/investigate/sol_best_practices.md
@@ -107,7 +107,7 @@ Use this table to identify which operations can be pushed down to the datasource
 | `\| aggregate <aggregations>` | When `<aggregations>` operate on simple field references. Only the first `aggregate` command can be pushed down |
 | `\| limit ...` | ✅ Always |
 | `\| top X by <definitions>` | When `<definitions>` are simple field references. For the `events` and `eternal_events` datasources, `top` cannot be pushed down after an aggregation |
-| `\| where <conditions>` | When `<conditions>` are simple comparison expressions over simple field references, or a `cidr_match()` predicate over a supported IP field |
+| `\| where <conditions>` | When `<conditions>` are simple comparison expressions over simple field references, or a `cidr_match()` predicate over a simple IP field reference such as `source.ip` (see [cidr_match()](/xdr/features/investigate/sol_ref_functions.md#network-cidr_match)) |
 | Constants and time functions (e.g. `now()`, `ago(24h)`) | ✅ Always |
 | Group-by time functions (`bin`, `year`, `month`, `week`) | ✅ Always |
 | `countif` aggregation function | ❌ Never |

--- a/docs/xdr/features/investigate/sol_datasets.md
+++ b/docs/xdr/features/investigate/sol_datasets.md
@@ -209,6 +209,24 @@ Imported datasets can be used like any other SOL data source:
     | claire.martin   | Front-End Engineer        |
     | david.chen      | Back-End Engineer         |
 
+### Enrich events using a CIDR dataset
+
+Use a dataset with `cidr` and `label` columns to enrich events whose source IP belongs to one of its IPv4 CIDR ranges. First derive the CIDR array and filter events with `where cidr_match(source.ip, cidrs)`. This filter can be pushed down to the event datasource, whereas the predicate lookup cannot. Performing the lookup only after filtering reduces the rows that must be matched. Keep the lookup dataset small enough to fit in memory.
+
+```shell
+let cidrs = cidr_dataset_test | select cidr;
+
+events
+| where timestamp between (?time.start .. ?time.end)
+| where source.ip != null
+| where cidr_match(source.ip, cidrs)
+| lookup cidr_dataset_test
+    on cidr_match($left.source.ip, $right.cidr)
+    into matched_cidr
+| select source.ip, matched_cidr.cidr, matched_cidr.label
+| limit 100
+```
+
 ### Best practices for dataset queries
 
 **Performance optimization**

--- a/docs/xdr/features/investigate/sol_datasets.md
+++ b/docs/xdr/features/investigate/sol_datasets.md
@@ -209,24 +209,6 @@ Imported datasets can be used like any other SOL data source:
     | claire.martin   | Front-End Engineer        |
     | david.chen      | Back-End Engineer         |
 
-### Enrich events using a CIDR dataset
-
-Use a dataset with `cidr` and `label` columns to enrich events whose source IP belongs to one of its IPv4 CIDR ranges. First derive the CIDR array and filter events with `where cidr_match(source.ip, cidrs)`. This filter can be pushed down to the event datasource, whereas the predicate lookup cannot. Performing the lookup only after filtering reduces the rows that must be matched. Keep the lookup dataset small enough to fit in memory.
-
-```shell
-let cidrs = cidr_dataset_test | select cidr;
-
-events
-| where timestamp between (?time.start .. ?time.end)
-| where source.ip != null
-| where cidr_match(source.ip, cidrs)
-| lookup cidr_dataset_test
-    on cidr_match($left.source.ip, $right.cidr)
-    into matched_cidr
-| select source.ip, matched_cidr.cidr, matched_cidr.label
-| limit 100
-```
-
 ### Best practices for dataset queries
 
 **Performance optimization**
@@ -288,6 +270,35 @@ Instantly correlate your alerts with external threat intelligence feeds to disti
     | ------------------------ | -------------- | ------------------- | ------------------ |
     | SEKOIA Intelligence Feed | 143.198.133.245 | malware_c2         | high               |
     | Suspicious DNS Query     | 185.220.101.47 | tor_exit_node       | medium             |
+
+### Enrich events using a CIDR dataset
+
+Tag events whose source IP belongs to one of your known IPv4 ranges, such as VPN pools, partner networks or internet scanners. The dataset holds a `cidr` column and a `label` column.
+
+The `lookup` predicate uses `cidr_match()` and is not pushed down to the datasource. The `where cidr_match(source.ip, cidrs)` filter is optional but pushed down: it keeps only events that match a range before the in-memory lookup runs, which reduces the rows the lookup must process. Keep the dataset small enough to fit in memory.
+
+=== "Query"
+
+    ```shell
+    let cidrs = known_scanner_ranges | select cidr;
+
+    events
+    | where timestamp between (?time.start .. ?time.end)
+    | where cidr_match(source.ip, cidrs)
+    | lookup known_scanner_ranges
+        on cidr_match($left.source.ip, $right.cidr)
+        into matched_range
+    | select timestamp, source.ip, matched_range.cidr, matched_range.label
+    | limit 100
+    ```
+
+=== "Results"
+
+    | timestamp                | source.ip     | matched_range.cidr | matched_range.label |
+    | ------------------------ | ------------- | ------------------ | ------------------- |
+    | 2026-03-26T15:35:14.738Z | 80.94.95.12   | 80.94.95.0/24      | Internet scanner    |
+    | 2026-03-26T15:35:03.740Z | 198.51.100.47 | 198.51.100.0/24    | Partner network     |
+    | 2026-03-26T15:35:04.539Z | 80.94.95.201  | 80.94.95.0/24      | Internet scanner    |
 
 ### Understand event patterns across business units and system criticality
 

--- a/docs/xdr/features/investigate/sol_ref_functions.md
+++ b/docs/xdr/features/investigate/sol_ref_functions.md
@@ -460,7 +460,7 @@ cidr_match(<ip>, <cidr_or_cidrs>)
 **Parameters**
 
 - `ip`: An IPv4 address string or `null`.
-- `cidr_or_cidrs`: An IPv4 CIDR string, an array of IPv4 CIDR strings, or `null`.
+- `cidr_or_cidrs`: An IPv4 CIDR string, an array of IPv4 CIDR strings (including an array derived from a table using `select`), or `null`.
 
 **Return Value**
 
@@ -481,6 +481,17 @@ Returns `true` if `ip` belongs to at least one valid CIDR supplied in `cidr_or_c
 
     ``` shell
     cidr_match(source.ip, ["80.94.95.0/24", "198.51.100.0/24"])
+    ```
+
+    A table-derived array can also be used:
+
+    ```shell
+    let cidrs = cidr_dataset_test
+    | select cidr;
+    events
+    | where cidr_match(source.ip, cidrs)
+    | select source.ip
+    | limit 100
     ```
 
 

--- a/docs/xdr/features/investigate/sol_ref_functions.md
+++ b/docs/xdr/features/investigate/sol_ref_functions.md
@@ -447,6 +447,43 @@ Returns the modified string with all non-overlapping matches replaced. If no mat
         | 2026-03-26T15:35:04.539Z | grace@example.com |
 
 
+## Network: cidr_match()
+
+Returns `true` when an IPv4 address belongs to an IPv4 CIDR range.
+
+**Syntax**
+
+``` shell
+cidr_match(<ip>, <cidr_or_cidrs>)
+```
+
+**Parameters**
+
+- `ip`: An IPv4 address string or `null`.
+- `cidr_or_cidrs`: An IPv4 CIDR string, an array of IPv4 CIDR strings, or `null`.
+
+**Return Value**
+
+Returns `true` if `ip` belongs to at least one valid CIDR supplied in `cidr_or_cidrs`; otherwise returns `false`. The function supports IPv4 only. Invalid IP addresses, invalid CIDRs, `null` values, and non-string array elements do not match. CIDRs with host bits are accepted and normalized.
+
+!!! example "Filter events by an IPv4 CIDR range"
+
+    === "Query"
+
+        ``` shell
+        events
+        | where cidr_match(source.ip, "80.94.95.0/24")
+        | select source.ip
+        | limit 100
+        ```
+
+    An array can be used to match against multiple ranges:
+
+    ``` shell
+    cidr_match(source.ip, ["80.94.95.0/24", "198.51.100.0/24"])
+    ```
+
+
 ## Math: round()
 
 **Description**

--- a/docs/xdr/features/investigate/sol_ref_functions.md
+++ b/docs/xdr/features/investigate/sol_ref_functions.md
@@ -449,7 +449,9 @@ Returns the modified string with all non-overlapping matches replaced. If no mat
 
 ## Network: cidr_match()
 
-Returns `true` when an IPv4 address belongs to an IPv4 CIDR range.
+**Description**
+
+Returns `true` when an IPv4 address belongs to an IPv4 CIDR range. Use it to filter events by network range, or to match events against a list of ranges held in a variable or a SOL dataset.
 
 **Syntax**
 
@@ -459,12 +461,18 @@ cidr_match(<ip>, <cidr_or_cidrs>)
 
 **Parameters**
 
-- `ip`: An IPv4 address string or `null`.
-- `cidr_or_cidrs`: An IPv4 CIDR string, an array of IPv4 CIDR strings (including an array derived from a table using `select`), or `null`.
+- `ip`: The IPv4 address to test, as a string (required)
+- `cidr_or_cidrs`: An IPv4 CIDR string, or an array of IPv4 CIDR strings. The array can be a literal or derived from a table with `select` (required)
 
 **Return Value**
 
-Returns `true` if `ip` belongs to at least one valid CIDR supplied in `cidr_or_cidrs`; otherwise returns `false`. The function supports IPv4 only. Invalid IP addresses, invalid CIDRs, `null` values, and non-string array elements do not match. CIDRs with host bits are accepted and normalized.
+Returns `true` if `ip` belongs to at least one valid CIDR in `cidr_or_cidrs`, otherwise `false`. The function supports IPv4 only. The following inputs never match: invalid IP addresses, invalid CIDRs, `null` values and array elements that are not strings.
+
+!!! note "Host bits are normalized"
+    A CIDR whose host bits are set is accepted and normalized to its network address. For example, `10.1.2.3/24` is treated as `10.1.2.0/24`.
+
+!!! tip "Push-down"
+    A `where cidr_match(...)` filter is pushed down to the `events` datasource. Apply it before a `lookup` or `join` so that only matching events reach the in-memory step. See [Enrich events using a CIDR dataset](/xdr/features/investigate/sol_datasets.md#enrich-events-using-a-cidr-dataset).
 
 !!! example "Filter events by an IPv4 CIDR range"
 
@@ -472,27 +480,61 @@ Returns `true` if `ip` belongs to at least one valid CIDR supplied in `cidr_or_c
 
         ``` shell
         events
+        | where timestamp > ago(24h)
         | where cidr_match(source.ip, "80.94.95.0/24")
-        | select source.ip
+        | select timestamp, source.ip, destination.ip
         | limit 100
         ```
 
-    An array can be used to match against multiple ranges:
+    === "Results"
 
-    ``` shell
-    cidr_match(source.ip, ["80.94.95.0/24", "198.51.100.0/24"])
-    ```
+        | timestamp                | source.ip    | destination.ip |
+        | ------------------------ | ------------ | -------------- |
+        | 2026-03-26T15:35:14.738Z | 80.94.95.12  | 192.168.2.10   |
+        | 2026-03-26T15:35:03.740Z | 80.94.95.201 | 192.168.2.22   |
+        | 2026-03-26T15:35:04.539Z | 80.94.95.12  | 192.168.2.10   |
 
-    A table-derived array can also be used:
+!!! example "Match against several ranges"
 
-    ```shell
-    let cidrs = cidr_dataset_test
-    | select cidr;
-    events
-    | where cidr_match(source.ip, cidrs)
-    | select source.ip
-    | limit 100
-    ```
+    === "Query"
+
+        ``` shell
+        events
+        | where timestamp > ago(24h)
+        | where cidr_match(source.ip, ["80.94.95.0/24", "198.51.100.0/24"])
+        | select timestamp, source.ip
+        | limit 100
+        ```
+
+    === "Results"
+
+        | timestamp                | source.ip      |
+        | ------------------------ | -------------- |
+        | 2026-03-26T15:35:14.738Z | 80.94.95.12    |
+        | 2026-03-26T15:35:03.740Z | 198.51.100.47  |
+
+!!! example "Match against the ranges of a SOL dataset"
+
+    The `known_scanner_ranges` dataset holds a `cidr` column. The `let` statement turns that column into an array.
+
+    === "Query"
+
+        ``` shell
+        let cidrs = known_scanner_ranges | select cidr;
+
+        events
+        | where timestamp > ago(24h)
+        | where cidr_match(source.ip, cidrs)
+        | select timestamp, source.ip
+        | limit 100
+        ```
+
+    === "Results"
+
+        | timestamp                | source.ip      |
+        | ------------------------ | -------------- |
+        | 2026-03-26T15:35:14.738Z | 80.94.95.12    |
+        | 2026-03-26T15:35:03.740Z | 198.51.100.47  |
 
 
 ## Math: round()

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -846,8 +846,7 @@ Use the `lookup` operator to extend a table with values from another table. Pref
     count the same source row more than once.
 
     When you need to count source events uniquely, use `count_distinct()` with an
-    event identifier. A timestamp can be used only when it uniquely identifies an
-    event in the queried data.
+    event identifier.
 
 For simple equality lookups, use a field comparison:
 

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -833,47 +833,51 @@ Unlike `inner` or `left` joins, anti-joins do **not** produce a `model` object â
 
 ## Lookup
 
-
-
 Use the `lookup` operator to extend a table with values from another table. Prefer `lookup` over `join` when the right table is small enough to fit into memory to improve query performance.
 
-!!! info
-    A lookup is a left lookup: all rows from the left table remain in the result. For an unmatched row, the `into` output is empty. When multiple rows in the right table match, the result includes an enriched row for each match.
+Like `join`, `lookup` injects the right table into a `model` object. The `into` clause names that object. Without `into`, the object takes a default name derived from the right table name, as for `join`. The result does not repeat the right table columns used in the matching condition.
+
+!!! note "A lookup is always a left lookup"
+    All rows from the left table remain in the result. For an unmatched row, the `model` object is empty. When several rows of the right table match, the result contains one enriched row per match.
 
 !!! warning "Multiple matches and aggregations"
-    When a lookup predicate matches multiple rows in the right table, the lookup
-    returns one enriched row for each match. Subsequent aggregations can therefore
-    count the same source row more than once.
+    When a lookup condition matches several rows in the right table, the lookup returns one enriched row per match. A subsequent `aggregate` can therefore count the same source row more than once. The same applies to `join`.
 
-    When you need to count source events uniquely, use `count_distinct()` with an
-    event identifier.
+    To count source events uniquely, use `count_distinct()` on an event identifier.
 
-For simple equality lookups, use a field comparison:
+For an equality lookup, compare one column of each table:
 
 ``` shell
 <left table name>
-| lookup <right table name> on <left column name> == <right column name>
+| lookup <right table name> on <left column name> == <right column name> into <model object name>
 ```
 
-Use a predicate lookup for more complex matching conditions, such as function calls or range comparisons:
+For more complex matching conditions, such as a function call or a range comparison, use a predicate lookup:
 
 ``` shell
 <left table name>
 | lookup <right table name>
     on <predicate>
-    into <output>
+    into <model object name>
 ```
 
-In a predicate lookup, explicitly qualify every field from the left table with `$left.` and every field from the right table with `$right.`. For example:
+In a predicate lookup, qualify every field of the left table with `$left.` and every field of the right table with `$right.`.
 
-``` shell
-events
-| lookup cidr_dataset_test
-    on cidr_match($left.source.ip, $right.cidr)
-    into matched_cidr
-```
+!!! example "Enrich events with the label of a matching CIDR range"
 
-For a complete example of enriching events with a CIDR dataset, including event filtering before the lookup, see [Enrich events using a CIDR dataset](/xdr/features/investigate/sol_datasets.md#enrich-events-using-a-cidr-dataset).
+    The `known_scanner_ranges` dataset holds `cidr` and `label` columns.
+
+    ``` shell
+    events
+    | where timestamp > ago(24h)
+    | lookup known_scanner_ranges
+        on cidr_match($left.source.ip, $right.cidr)
+        into matched_range
+    | select timestamp, source.ip, matched_range.label
+    | limit 100
+    ```
+
+A predicate lookup is not pushed down to the datasource. For the complete pattern, which filters events with `cidr_match()` before the lookup, see [Enrich events using a CIDR dataset](/xdr/features/investigate/sol_datasets.md#enrich-events-using-a-cidr-dataset).
 
 
 ## Compare

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -840,14 +840,14 @@ Use the `lookup` operator to extend a table with values from another table. Pref
 !!! info
     A lookup is a left lookup: all rows from the left table remain in the result. For an unmatched row, the `into` output is empty. When multiple rows in the right table match, the result includes an enriched row for each match.
 
-An indexed lookup compares one field from each table. This legacy syntax remains supported:
+For simple equality lookups, use a field comparison:
 
 ``` shell
 <left table name>
 | lookup <right table name> on <left column name> == <right column name>
 ```
 
-For a non-trivial condition, use a predicate lookup:
+Use a predicate lookup for more complex matching conditions, such as function calls or range comparisons:
 
 ``` shell
 <left table name>
@@ -856,7 +856,7 @@ For a non-trivial condition, use a predicate lookup:
     into <output>
 ```
 
-In a non-trivial predicate, explicitly qualify every field from the left table with `$left.` and every field from the right table with `$right.`. For example:
+In a predicate lookup, explicitly qualify every field from the left table with `$left.` and every field from the right table with `$right.`. For example:
 
 ``` shell
 events

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -865,7 +865,7 @@ events
     into matched_cidr
 ```
 
-See [Enrich events using a CIDR dataset](/xdr/features/investigate/sol_datasets.md#enrich-events-using-a-cidr-dataset) for a performant query that filters events before this lookup.
+For a complete example of enriching events with a CIDR dataset, including event filtering before the lookup, see [Enrich events using a CIDR dataset](/xdr/features/investigate/sol_datasets.md#enrich-events-using-a-cidr-dataset).
 
 
 ## Compare

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -840,6 +840,15 @@ Use the `lookup` operator to extend a table with values from another table. Pref
 !!! info
     A lookup is a left lookup: all rows from the left table remain in the result. For an unmatched row, the `into` output is empty. When multiple rows in the right table match, the result includes an enriched row for each match.
 
+!!! warning "Multiple matches and aggregations"
+    When a lookup predicate matches multiple rows in the right table, the lookup
+    returns one enriched row for each match. Subsequent aggregations can therefore
+    count the same source row more than once.
+
+    When you need to count source events uniquely, use `count_distinct()` with an
+    event identifier. A timestamp can be used only when it uniquely identifies an
+    event in the queried data.
+
 For simple equality lookups, use a field comparison:
 
 ``` shell

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -835,22 +835,37 @@ Unlike `inner` or `left` joins, anti-joins do **not** produce a `model` object â
 
 
 
-Use the `lookup` operator to extend a table. Extends the current table with values looked-up in another table.
-Prefer the `lookup` operator over `join` when the right table is small enough to fit into memory to improve query performance.
+Use the `lookup` operator to extend a table with values from another table. Prefer `lookup` over `join` when the right table is small enough to fit into memory to improve query performance.
 
 !!! info
-    The result doesn't repeat columns from the `right` table that are the basis for the join operation.
-    The `lookup` operator only supports `left join`.
+    A lookup is a left lookup: all rows from the left table remain in the result. For an unmatched row, the `into` output is empty. When multiple rows in the right table match, the result includes an enriched row for each match.
+
+An indexed lookup compares one field from each table. This legacy syntax remains supported:
 
 ``` shell
 <left table name>
 | lookup <right table name> on <left column name> == <right column name>
-| aggregate <function> by <column name>
-| order by <column name>
-
 ```
 
-Similarly to `join` operator, `lookup` will inject the right table into a `model` object.
+For a non-trivial condition, use a predicate lookup:
+
+``` shell
+<left table name>
+| lookup <right table name>
+    on <predicate>
+    into <output>
+```
+
+In a non-trivial predicate, explicitly qualify every field from the left table with `$left.` and every field from the right table with `$right.`. For example:
+
+``` shell
+events
+| lookup cidr_dataset_test
+    on cidr_match($left.source.ip, $right.cidr)
+    into matched_cidr
+```
+
+See [Enrich events using a CIDR dataset](/xdr/features/investigate/sol_datasets.md#enrich-events-using-a-cidr-dataset) for a performant query that filters events before this lookup.
 
 
 ## Compare


### PR DESCRIPTION
Document SOL IPv4 CIDR matching and dataset enrichment:

- Add `cidr_match()` reference material, including table-derived CIDR arrays and push-down guidance.
- Document predicate lookup syntax, `$left`/`$right` field qualification, legacy indexed lookup compatibility, and left/multiple-match behavior.
- Add an efficient CIDR dataset enrichment workflow that filters events with `where cidr_match(source.ip, cidrs)` before the non-push-down predicate lookup.