### PR TITLE
docs: add Geo Map visualization

### DIFF
--- a/docs/xdr/features/investigate/data_visualization_guide.md
+++ b/docs/xdr/features/investigate/data_visualization_guide.md
@@ -2,7 +2,7 @@
 
 The Query Builder offers various options for displaying your results depending on your analytical needs. These visualizations help you transform raw data into actionable insights for reporting and threat hunting.
 
-The query builder offers seven visualization options, grouped into two categories:
+The query builder offers eight visualization options, grouped into two categories:
 
 1. **Total values**: Focuses on comparing values across different categories at a specific point in time.
 2. **Time series**: Highlights how data evolves over time, enabling the analysis of trends and changes.
@@ -69,6 +69,40 @@ The Sankey Chart visualizes flows between entities, making it ideal for mapping 
     | limit 50
     | render sankey with (source=source.ip, target=destination.ip, value=count)
     ```
+
+### Geo Map
+The Geo Map visualizes the geographic distribution of events. Use it to identify the countries from which activity originates, investigate geographic hotspots, or present the reach of an incident.
+
+The visualization supports two modes:
+
+* **Choropleth**: colors countries according to a value.
+* **Bubble map**: displays bubbles at geographic coordinates. Bubble size represents a value.
+
+**Configuration**:
+
+* For a **choropleth**, select a **Country** field containing ISO 3166-1 alpha-2 country codes or full English country names. Optionally select a numeric **Value** field to control the color intensity.
+* For a **bubble map**, select numeric **Latitude** and **Longitude** fields. Optionally select a **Label** field for the tooltip and a numeric **Value** field to control bubble size.
+* The **Country** field cannot be used with **Latitude** and **Longitude** fields in the same visualization.
+
+!!! tip "SOL syntax"
+
+    Use `render geomap` with either the `country` parameter or the `lat` and `lon` parameters.
+
+    === "Choropleth"
+
+        ```shell
+        events
+        | aggregate count() by source.geo.country_iso_code
+        | render geomap with (country=source.geo.country_iso_code, value=count)
+        ```
+
+    === "Bubble map"
+
+        ```shell
+        events
+        | aggregate count() by source.geo.location.lat, source.geo.location.lon
+        | render geomap with (lat=source.geo.location.lat, lon=source.geo.location.lon, label=source.geo.city_name, value=count)
+        ```
 
 ## Time series visualizations
 

--- a/docs/xdr/features/investigate/notebooks.md
+++ b/docs/xdr/features/investigate/notebooks.md
@@ -119,7 +119,7 @@ The `default` notebook template will be suggested for use in cases and alerts, e
 
 ### Query Builder Editor
 * Display data in tables
-* Create various data visualizations, including pie charts, line charts, bar charts, column charts, Sankey charts, and numeric displays
+* Create various data visualizations, including pie charts, line charts, bar charts, column charts, Sankey charts, geo maps, and numeric displays
 
 ![notebook_viz](/assets/operation_center/notebook_viz.png){: style="max-width:100%"}
 

--- a/docs/xdr/features/investigate/sol_how_to_guides.md
+++ b/docs/xdr/features/investigate/sol_how_to_guides.md
@@ -204,6 +204,7 @@ Use the `render` operator to display query results as charts. Supported chart ty
 - `barchart` — Horizontal bar chart
 - `linechart` — Line chart
 - `sankey` — Flow chart
+- `geomap` — Geographic visualization
 
 ### Basic chart
 
@@ -248,6 +249,29 @@ Use `breakdown_by` to split data into series, and `mode` to control stacking:
     | 2026-03-21T00:00:00.000Z | network        | 1734  |
 
 For the full operator reference, see [Render results in chart](sol_ref_operators.md#render-results-in-chart).
+
+### Geographic visualization
+
+Use `geomap` to visualize event distribution by country or geographic coordinates. For a country-based map, provide a country column containing ISO 3166-1 alpha-2 codes or full English country names. For a coordinate-based map, provide latitude and longitude columns instead.
+
+=== "By country"
+
+    ```shell
+    events
+    | where timestamp > ago(24h)
+    | where event.category == "authentication" and action.outcome == "failure"
+    | aggregate count() by source.geo.country_iso_code
+    | render geomap with (country=source.geo.country_iso_code, value=count)
+    ```
+
+=== "By coordinates"
+
+    ```shell
+    events
+    | where timestamp > ago(24h)
+    | aggregate count() by source.geo.location.lat, source.geo.location.lon
+    | render geomap with (lat=source.geo.location.lat, lon=source.geo.location.lon, label=source.geo.city_name, value=count)
+    ```
 
 
 ## How to use external data with SOL Datasets

--- a/docs/xdr/features/investigate/sol_overview.md
+++ b/docs/xdr/features/investigate/sol_overview.md
@@ -11,7 +11,7 @@ Sekoia.io provides two ways to search and analyze your security data:
 | **Interface** | UI-based search with filters and buttons | Code-based query editor |
 | **Best for** | Quick searches, viewing individual logs, adding events to cases | Complex analytics, aggregations, cross-table joins, dashboards |
 | **Query language** | [Events Query Language](events_query_language.md) with filter badges | SOL with full operator and function support |
-| **Visualization** | Histogram with basic aggregation | Charts (bar, line, pie, column) with full render control |
+| **Visualization** | Histogram with basic aggregation | Charts (bar, line, pie, column, Sankey, geo map) with full render control |
 | **Data sources** | Events only | Events, alerts, cases, assets, intakes, communities, and more |
 | **Saving & sharing** | Browser-based saved queries | Persistent saved queries, shared across team, dashboard widgets |
 

--- a/docs/xdr/features/investigate/sol_ref_operators.md
+++ b/docs/xdr/features/investigate/sol_ref_operators.md
@@ -602,6 +602,7 @@ Use the `render` operator to display results in a chart to identify more easily 
 - `barchart`
 - `linechart`
 - `sankey`
+- `geomap`
 
 ``` shell
 <table name>
@@ -618,6 +619,24 @@ For the `sankey` chart, the syntax uses `source`, `target`, and `value` paramete
 | render sankey with (source=<source column>, target=<target column>, value=<value column>)
 
 ```
+
+For the `geomap` chart, use one of the following syntaxes:
+
+``` shell
+<table name>
+| aggregate <function> by <country column>
+| render geomap with (country=<country column>, value=<value column>)
+
+```
+
+``` shell
+<table name>
+| aggregate <function> by <latitude column>, <longitude column>
+| render geomap with (lat=<latitude column>, lon=<longitude column>, label=<label column>, value=<value column>)
+
+```
+
+The `country` parameter accepts ISO 3166-1 alpha-2 country codes and full English country names. Use either `country` or the `lat` and `lon` parameters; they cannot be combined. The `label` and `value` parameters are optional.
 
 !!! example "Count the number of events per asset in the events table and render it in a bar chart"
 
@@ -656,6 +675,23 @@ For the `sankey` chart, the syntax uses `source`, `target`, and `value` paramete
     === "Results"
 
         A Sankey chart showing the volume of connections from each source IP to each destination IP.
+
+!!! example "Visualize authentication failures by source country on a map"
+
+    === "Query"
+
+        ``` shell
+        events
+        | where timestamp > ago(24h)
+        | where event.category == "authentication" and action.outcome == "failure"
+        | aggregate count() by source.geo.country_iso_code
+        | render geomap with (country=source.geo.country_iso_code, value=count)
+
+        ```
+
+    === "Results"
+
+        A world map in which each country is colored according to the number of authentication failures originating from it.
 
 ## Join tables
 


### PR DESCRIPTION
## Summary

Document the `geomap` visualization for SOL queries and notebooks.

- Describe choropleth and bubble-map modes in the data visualization guide
- Add SOL `render geomap` syntax, parameters, and a country-based example
- List Geo Map in notebooks, SOL how-to guides, and the SOL overview

Closes #87085