### PR TITLE
docs(developer): list the playbook endpoints under Automation instead of Reporting

### DIFF
--- a/docs/developer/api.md
+++ b/docs/developer/api.md
@@ -188,8 +188,7 @@ template: overrides/openapi.html
                         "Rules",
                         "Alert filters",
                         "Assets",
-                        "Playbooks",
-                            "Automation statistics", // => Playbooks
+                        "Automation statistics",
                         "AI assistant",
                         "Statistics", // ?
                     ]


### PR DESCRIPTION
The playbook management endpoints of symphony were listed under the Reporting section of the API reference instead of Automation, as reported by Antoine during a workshop. The "Playbooks" tag was declared in both sections of the menu and the viewer kept the Reporting one. This removes it from Reporting, where only the automation statistics endpoints belong, so the playbook endpoints now show up under Automation.